### PR TITLE
removes spotify id column from playlist

### DIFF
--- a/db/migrate/20230322045111_remove_spotify_id_from_playlists.rb
+++ b/db/migrate/20230322045111_remove_spotify_id_from_playlists.rb
@@ -1,0 +1,5 @@
+class RemoveSpotifyIdFromPlaylists < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :playlists, :spotify_id, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_22_043753) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_22_045111) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,7 +69,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_22_043753) do
     t.datetime "updated_at", null: false
     t.string "title", null: false
     t.bigint "user_id", null: false
-    t.string "spotify_id", null: false
     t.index ["user_id"], name: "index_playlists_on_user_id"
   end
 


### PR DESCRIPTION
# Description

removes spotify id column from playlist as we are no longer saving to user's account

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
schema has been checked following migration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
