### PR TITLE
adds condition to check filtered songs count

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -26,9 +26,8 @@ class PlaylistsController < ApplicationController
     # filter the user's songs with event
     filter_songs(@event)
 
-
+    @songs_uri.count > 100 ? @spotify_playlist.add_tracks!(@song_uris.sample(100)) : @spotify_playlist.add_tracks!(@song_uris)
     # add tracks to spotify playlist by
-    @spotify_playlist.add_tracks!(@song_uris.sample(100))
 
     # create instacne of playlist in out database wihtout phtot
     # make title dynamic!!


### PR DESCRIPTION
# Description

Adds condition to check number of filtered songs, if >100 then sample 100, as spotify API max 100 tracks per playlist

Fixes # (issue)
(https://trello.com/c/la07WFaP)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Works on local machine but it was broken on heroku so need to test there

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
