### PR TITLE
Reloads playlist new and playlist show pages

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -11,14 +11,16 @@ class PlaylistsController < ApplicationController
   def show
     # show requires an "id" variable to insert into embeded iframe
     @playlist = Playlist.find(params[:id])
+
   end
 
   # GET /events/:event_id/playlists/new
   def new
+    @event = Event.find(params[:event_id])
     @playlist = Playlist.new
-
     @event = Event.find(params[:event_id])
     filter_songs(@event)
+
   end
 
   # POST /events/:event_id/playlists

--- a/app/javascript/webplayback/index.js
+++ b/app/javascript/webplayback/index.js
@@ -1,17 +1,18 @@
 window.onSpotifyIframeApiReady = (IFrameAPI) => {
-  let element = document.getElementById('embed-iframe');
+  let element = document.getElementById("embed-iframe");
   let options = {
-      width: '70%',
-      height: '400px',
-      uri: document.getElementById('first-song').getAttribute('value')
-    };
+    width: "70%",
+    height: "400px",
+    uri: document.getElementById("first-song").getAttribute("value"),
+  };
   let callback = (EmbedController) => {
-    document.querySelectorAll('ul#episodes > li > button').forEach(
-      episode => {
-        episode.addEventListener('click', () => {
-          EmbedController.loadUri(episode.dataset.spotifyId)
+    document
+      .querySelectorAll("ul#episodes > li > button")
+      .forEach((episode) => {
+        episode.addEventListener("click", () => {
+          EmbedController.loadUri(episode.dataset.spotifyId);
         });
-      })
-    };
+      });
+  };
   IFrameAPI.createController(element, options, callback);
 };

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -1,9 +1,24 @@
+<script>
+  function reloadPage() {
+  // The last "domLoading" Time //
+  let currentDocumentTimestamp =
+  new Date(performance.timing.domLoading).getTime();
+  // Current Time //
+  let now = Date.now();
+  // Ten Seconds //
+  let oneSec = 1 * 1000;
+  // Plus Ten Seconds //
+  let plusOneSec = currentDocumentTimestamp + oneSec;
+  if (now > plusOneSec) {
+  location.reload();
+  } else {}
+  }
+  reloadPage();
+</script>
 <h1>New Playlist</h1>
-
 <div id="first-song" value="<%= @song_uris.first %>"></div>
 <div class="d-flex justify-content-center align-items-start gap-3 flex-wrap">
   <div id="embed-iframe"></div>
-
   <div class="flex-grow-1 episodes-container">
     <ul id="episodes" class="list-unstyled">
       <% @songs.first(20).each do |song| %>
@@ -11,13 +26,12 @@
           <button class="btn episodes-button" data-spotify-id=<%= song.uri %>>
             <%= song.name %> - <%= song.artist %>
           </button>
-        </li>
-      <% end %>
-    </ul>
+          </li>
+        <% end %>
+      </ul>
+    </div>
   </div>
-</div>
-
-<%= simple_form_for [@event, @playlist], defaults: { required: false }  do |f| %>
-      <%= f.input :title, :label => "Playlist Title", placeholder: "Name your playlist" %>
-      <%= f.submit "Create Playlist", class: "btn oauth-signin" %>
-<% end %>
+  <%= simple_form_for [@event, @playlist], defaults: { required: false }  do |f| %>
+    <%= f.input :title, :label => "Playlist Title", placeholder: "Name your playlist" %>
+    <%= f.submit "Create Playlist", class: "btn oauth-signin" %>
+  <% end %>

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -24,16 +24,18 @@
       <% @songs.each do |song| %>
         <li class="episodes">
           <button class="btn episodes-button" data-spotify-id=<%= song.uri %>>
-            <%= song.name %> - <%= song.artist %>
-          </button>
+              <%= song.name %> - <%= song.artist %>
+            </button>
           </li>
         <% end %>
       </ul>
     </div>
   </div>
 </div>
-<%= simple_form_for [@event, @playlist], defaults: { required: false }  do |f| %>
-  <%= f.input :title, :label => "Playlist Title", placeholder: "Name your playlist" %>
-  <%= f.input :photo, as: :file, label: "Upload your photo", input_html: { class: "bg-white py-1" }, wrapper_html: { class: "fs-6 mt-2 text-dark fw-normal" } %>
-  <%= f.submit "Create Playlist", class: "btn oauth-signin" %>
-<% end %>
+<div class="mb-5">
+  <%= simple_form_for [@event, @playlist], defaults: { required: false }  do |f| %>
+    <%= f.input :title, :label => "Playlist Title", placeholder: "Name your playlist" %>
+    <%= f.input :photo, as: :file, label: "Upload your photo", wrapper_html: { class: "fs-6 mt-2 fw-normal" } %>
+    <%= f.submit "Create Playlist", class: "btn oauth-signin" %>
+  <% end %>
+</div>

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -1,5 +1,21 @@
+<script>
+  function reloadPage() {
+  // The last "domLoading" Time //
+  let currentDocumentTimestamp =
+  new Date(performance.timing.domLoading).getTime();
+  // Current Time //
+  let now = Date.now();
+  // Ten Seconds //
+  let oneSec = 1 * 1000;
+  // Plus Ten Seconds //
+  let plusOneSec = currentDocumentTimestamp + oneSec;
+  if (now > plusOneSec) {
+  location.reload();
+  } else {}
+  }
+  reloadPage();
+</script>
 <h1><%= @playlist.title %></h1>
-
 <div class="container">
   <iframe id="playlist-show" style="border-radius:12px" src="https://open.spotify.com/embed/playlist/<%= @playlist.spotify_id %>?utm_source=generator&theme=0" width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
 </div>


### PR DESCRIPTION
# Description
to fix the heroku issue.
uses JS to reload playlist new and show pages for now.

Fixes # (issue)
https://trello.com/c/3zLzCK1Z

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
On local machine.

- [ ] reloads the webplayer SDK and iframe so we can see the songs
<img width="374" alt="Screenshot 2023-03-24 at 3 39 48 PM" src="https://user-images.githubusercontent.com/99415923/227456135-180931fe-2ef8-4b6b-938c-ddfcc2578fd4.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
