### PR TITLE
Make dynamic iframes

### DIFF
--- a/app/views/shared/_menu_bar.html.erb
+++ b/app/views/shared/_menu_bar.html.erb
@@ -5,7 +5,7 @@
     </div>
   <% end %>
 
-  <%= link_to playlist_path(Playlist.first) do %>
+  <%= link_to (current_user.playlists.nil? ? new_event_path : playlist_path(current_user.playlists.first)) do %>
     <div class="px-3">
       <i class="fa-solid fa-headphones fa-md"></i>
     </div>

--- a/app/views/shared/_menu_bar.html.erb
+++ b/app/views/shared/_menu_bar.html.erb
@@ -5,7 +5,7 @@
     </div>
   <% end %>
 
-  <%= link_to (current_user.playlists.nil? ? new_event_path : playlist_path(current_user.playlists.first)) do %>
+  <%= link_to (current_user.playlists.nil? ? new_event_path : playlist_path(current_user.playlists.last)) do %>
     <div class="px-3">
       <i class="fa-solid fa-headphones fa-md"></i>
     </div>

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -9,7 +9,7 @@
             </div>
           </div>
           <div class="profile_card__face profile_card__face--back">
-              <iframe style="border-radius:12px;" src="https://open.spotify.com/embed/playlist/1UCY5fAnCk6w590OuAWvFS?utm_source=generator&theme=0" width="100%" height="100%" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+              <iframe style="border-radius:12px;" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="100%" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Description

- Makes frames in the vault and user galleries dynamic
- Makes music page dynamic (If not playlist created, redirect to new_event_path; if playlist exist, redirect to last playlist created)

Fixes # (issue)
https://trello.com/c/n52UqCk7

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Screenshot A - Redirects to last playlist created if playlists exists
<img width="355" alt="Screenshot 2023-03-24 at 4 03 56 PM" src="https://user-images.githubusercontent.com/118903492/227460758-11723c5b-d587-4148-8f1a-1279b83b9db1.png">

- [x] Screenshot B - Vault cards now show playlists that it belongs to
<img width="400" alt="Screenshot 2023-03-24 at 4 04 34 PM" src="https://user-images.githubusercontent.com/118903492/227460885-4d02504a-ef0c-4a3a-ae02-02f46cc0ddc2.png">

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
