### PR TITLE
Fixes menu-bar if playlist empty]

### DIFF
--- a/app/views/shared/_menu_bar.html.erb
+++ b/app/views/shared/_menu_bar.html.erb
@@ -5,7 +5,7 @@
     </div>
   <% end %>
 
-  <%= link_to (current_user.playlists.nil? ? new_event_path : playlist_path(current_user.playlists.last)) do %>
+  <%= link_to (current_user.playlists.empty? ? new_event_path : playlist_path(current_user.playlists.last)) do %>
     <div class="px-3">
       <i class="fa-solid fa-headphones fa-md"></i>
     </div>


### PR DESCRIPTION
# Description

Fixes menu-bar to show new event path when playlist of user is empty.

Fixes # (issue)
https://trello.com/c/2ULN1fAp

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
