### PR TITLE
Adds Javascript to get local time of the user

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -21,3 +21,6 @@ application.register("profile-card", ProfileCardController)
 
 import SliderController from "./slider_controller"
 application.register("slider", SliderController)
+
+import TimeZoneController from "./time_zone_controller"
+application.register("time-zone", TimeZoneController)

--- a/app/javascript/controllers/time_zone_controller.js
+++ b/app/javascript/controllers/time_zone_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="time-zone"
+export default class extends Controller {
+  static targets = ["dayPeriod"]
+
+  connect() {
+    const date = new Date();
+    const hour = date.getHours();
+
+    let period = "evening";
+    if (hour >= 5 && hour < 12) {
+    period = "morning";
+    } else if (hour >= 12 && hour < 17) {
+      period = "afternoon";
+    }
+    this.dayPeriodTarget.innerText = period;
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,18 +35,6 @@ class User < ApplicationRecord
   def spotify_user
     RSpotify::User.new(spotify_auth)
   end
-  
-  def day_period
-    hour = Time.now.hour
-    period = "evening"
-    if (hour >= 5 && hour < 12)
-      period = "morning"
-    elsif (hour >= 12 && hour < 17)
-      period = "afternoon"
-    end
-
-    period
-  end
 
   def user_playlists
     Playlist.where(user: self)

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,5 +1,5 @@
-<div class="container">
-  <h2>Good <%= current_user.day_period %>, <em><%= current_user.nickname %></em></h2>
+<div class="container" data-controller="time-zone">
+  <h2>Good <span data-time-zone-target="dayPeriod"></span>, <em><%= current_user.nickname %></em></h2>
 </div>
 <!-- Carousel -->
 <div class="carousel" data-controller="flickity">


### PR DESCRIPTION
# Description
- use Javascript to get local time of the user's machine, and put the period of the day in the greeting at homepage
- previously, the period of the day is display that of the heroku server.

Fixes # (issue)
[https://trello.com/c/7C2c7Wns](https://trello.com/c/7C2c7Wns)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Morning
![image](https://user-images.githubusercontent.com/81938708/227612100-e41af27e-7d82-4f98-be94-7e77b7c6c189.png)

- [x] Afternoon
![image](https://user-images.githubusercontent.com/81938708/227612419-4c9c95b3-1765-4218-9334-4a0aa844ad9d.png)

- [x] Evening
![image](https://user-images.githubusercontent.com/81938708/227612634-06768e6f-38f3-40f5-abb3-61b5015fe7e6.png)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
