### PR TITLE
Bugfix: Gallery icon size and added play button

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,0 +1,34 @@
+.btn-play {
+  aspect-ratio: 1/1;
+  padding: 0.3em 1em 0.25em 1.5em;
+  font-size: 1em;
+  font-weight: bold;
+  border-radius: 50%;
+  color: #fff6fb;
+  letter-spacing: 0.3em;
+  text-shadow: -2px 2px 5px #FD3084;
+  background-color: transparent;
+  border: 2px solid #FEB1DE;
+  box-shadow: 0 0 0px 1px #F11271,
+    0 0 10px 2px #FD3084,
+    inset 0 0 0px 1px #F11271,
+    inset 0 0 10px 2px #FD3084;
+  transition: 100ms;
+
+  &:hover {
+    box-shadow: 0 0 0px 1px #F11271,
+    0 0 10px 2px #FD3084,
+    inset 0 0 0px 1px #F11271,
+    inset 0 0 30px 2px #FD3084;
+    text-shadow: 0 0 10px #FD3084;
+    transform: translateY(-5px);
+  }
+
+  &:active {
+    box-shadow: 0 0 0px 1px #F11271,
+    0 0 25px 2px #FD3084,
+    inset 0 0 0px 1px #F11271,
+    inset 0 0 30px 2px #FD3084;
+    transform: translateY(1px);
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -1,5 +1,6 @@
 // Import your components CSS files here.
 @import "avatar";
+@import "button";
 @import "carousel";
 @import "container";
 @import "event_card";

--- a/app/assets/stylesheets/components/_profile_card.scss
+++ b/app/assets/stylesheets/components/_profile_card.scss
@@ -1,7 +1,7 @@
 .profile-wrapper {
   width: auto;
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 4%;
   margin-left: 8%;
   margin-right: 8%;
@@ -73,6 +73,9 @@
 
 .profile_card__face--back {
   background: #282828;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   transform: rotateY(180deg);
   width: 100%;
   height: 100%;

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,3 +1,4 @@
 // Import your components CSS files here.
 @import "landing";
+@import "profile";
 @import "vault";

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -11,6 +11,12 @@
   z-index: 1;
 }
 
+.modal-container {
+  width: 85%;
+  margin: 0 auto;
+  margin-top: 5%;
+}
+
 .profile-modal {
   justify-content: center;
   align-items: center;
@@ -20,7 +26,13 @@
   top: 15%;
   left: 0;
   right: 0;
-  margin: auto
+  margin: auto;
+
+  background-color: rgba(255, 255, 255, 0.074);
+  border: 1px solid rgba(255, 255, 255, 0.222);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  border-radius: .5rem;
 }
 
 .hidden {

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -1,0 +1,17 @@
+.overlay-hidden {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(3px);
+  z-index: 1;
+}
+
+.profile-modal-hidden {
+  background-color: $light-gray;
+  z-index: 2;
+}

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -11,7 +11,18 @@
   z-index: 1;
 }
 
-.profile-modal-hidden {
+.profile-modal {
+  justify-content: center;
+  align-items: center;
   background-color: $light-gray;
   z-index: 2;
+  position: absolute;
+  top: 15%;
+  left: 0;
+  right: 0;
+  margin: auto
+}
+
+.hidden {
+  display: none;
 }

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -1,16 +1,3 @@
-.overlay-hidden {
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(3px);
-  z-index: 1;
-}
-
 .modal-container {
   width: 85%;
   margin: 0 auto;

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,5 +19,8 @@ application.register("logo", LogoController)
 import ProfileCardController from "./profile_card_controller"
 application.register("profile-card", ProfileCardController)
 
+import ProfileModalController from "./profile_modal_controller"
+application.register("profile-modal", ProfileModalController)
+
 import SliderController from "./slider_controller"
 application.register("slider", SliderController)

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -2,9 +2,21 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="profile-modal"
 export default class extends Controller {
-  static targets = ["modal", "overlay", "close", "open"]
+  static targets = ["modal", "overlay"]
 
   connect() {
     console.log("Connected");
+  }
+
+  open() {
+    console.log("Open modal");
+    this.modalTarget.classList.remove("hidden")
+    this.overlayTarget.classList.remove("hidden")
+  }
+
+  close() {
+    console.log("Close modal");
+    this.modalTarget.classList.add("hidden")
+    this.overlayTarget.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -2,6 +2,9 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="profile-modal"
 export default class extends Controller {
+  static targets = ["modal", "overlay", "close", "open"]
+
   connect() {
+    console.log("Connected");
   }
 }

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -5,10 +5,14 @@ export default class extends Controller {
   static targets = ["modal", "overlay"]
 
   open() {
-    this.modalTarget.classList.remove("hidden")
+    setTimeout(() => {
+      this.modalTarget.classList.remove("hidden")
+    }, 500);
   }
 
   close() {
-    this.modalTarget.classList.add("hidden")
+    setTimeout(() => {
+      this.modalTarget.classList.add("hidden")
+    }, 500);
   }
 }

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -4,19 +4,11 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["modal", "overlay"]
 
-  connect() {
-    console.log("Connected");
-  }
-
   open() {
-    console.log("Open modal");
     this.modalTarget.classList.remove("hidden")
-    this.overlayTarget.classList.remove("hidden")
   }
 
   close() {
-    console.log("Close modal");
     this.modalTarget.classList.add("hidden")
-    this.overlayTarget.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="profile-modal"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,6 +1,5 @@
 <div class="container">
   <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
-  <%= @user["images"] %>
-
-  <%= render "shared/profile", playlists: @playlists %>
 </div>
+
+<%= render "shared/profile", playlists: @playlists %>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,16 +1,16 @@
-<section class="profile-modal-hidden">
+<section class="profile-modal-hidden" data-controller="profile-modal" data-profile-modal-target="modal">
   <div class="container">
     <div class="d-flex justify-content-between align-items-center">
       <h1 class="m-0">Playlist Title</h1>
-      <i class="fa-solid fa-xmark"></i>
+      <i class="fa-solid fa-xmark" data-profile-modal-target="close"></i>
     </div>
     <iframe id="playlist-show" style="border-radius:12px" src="https://open.spotify.com/embed/playlist/7soJCNRvS1LTHaMcT4rTqg?utm_source=generator&theme=0" width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
   </div>
 </section>
 
-<div class="overlay-hidden"></div>
+<div class="overlay-hidden" data-controller="profile-modal" data-profile-modal-target="overlay"></div>
 
-<div class="container">
+<div class="container" data-controller="profile-modal">
   <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
 </div>
 <%= render "shared/profile", playlists: @playlists %>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,8 +1,4 @@
-<div data-controller="profile-modal">
-
-
-  <%# <div class="overlay-hidden" data-controller="profile-modal" data-profile-modal-target="overlay"></div> %>
-
+<div>
   <div class="container">
     <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
   </div>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,6 +1,6 @@
 <div data-controller="profile-modal">
-  <section class="profile-modal hidden" data-profile-modal-target="modal">
-    <div class="container">
+  <section class="profile-modal hidden" data-profile-modal-target="modal" style="margin:0 auto">
+    <div class="modal-container">
       <div class="d-flex justify-content-between align-items-center">
         <h1 class="m-0">Playlist Title</h1>
         <i class="fa-solid fa-xmark" data-action="click->profile-modal#close"></i>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,5 +1,14 @@
-<div class="container">
-  <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
-</div>
+<div class="overlay hidden">
+  <div class="container">
+    <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
+  </div>
 
-<%= render "shared/profile", playlists: @playlists %>
+<section class="profile-modal-hidden">
+  <div class="container">
+    <h1>Playlist Title</h1>
+    <iframe id="playlist-show" style="border-radius:12px" src="https://open.spotify.com/embed/playlist/7soJCNRvS1LTHaMcT4rTqg?utm_source=generator&theme=0" width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+  </div>
+</section>
+
+  <%= render "shared/profile", playlists: @playlists %>
+</div>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,16 +1,18 @@
-<section class="profile-modal-hidden" data-controller="profile-modal" data-profile-modal-target="modal">
-  <div class="container">
-    <div class="d-flex justify-content-between align-items-center">
-      <h1 class="m-0">Playlist Title</h1>
-      <i class="fa-solid fa-xmark" data-profile-modal-target="close"></i>
+<div data-controller="profile-modal">
+  <section class="profile-modal hidden" data-profile-modal-target="modal">
+    <div class="container">
+      <div class="d-flex justify-content-between align-items-center">
+        <h1 class="m-0">Playlist Title</h1>
+        <i class="fa-solid fa-xmark" data-action="click->profile-modal#close"></i>
+      </div>
+      <iframe id="playlist-show" style="border-radius:12px" src="https://open.spotify.com/embed/playlist/7soJCNRvS1LTHaMcT4rTqg?utm_source=generator&theme=0" width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
     </div>
-    <iframe id="playlist-show" style="border-radius:12px" src="https://open.spotify.com/embed/playlist/7soJCNRvS1LTHaMcT4rTqg?utm_source=generator&theme=0" width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+  </section>
+
+  <%# <div class="overlay-hidden" data-controller="profile-modal" data-profile-modal-target="overlay"></div> %>
+
+  <div class="container">
+    <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
   </div>
-</section>
-
-<div class="overlay-hidden" data-controller="profile-modal" data-profile-modal-target="overlay"></div>
-
-<div class="container" data-controller="profile-modal">
-  <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
+  <%= render "shared/profile", playlists: @playlists %>
 </div>
-<%= render "shared/profile", playlists: @playlists %>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,14 +1,16 @@
-<div class="overlay hidden">
-  <div class="container">
-    <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
-  </div>
-
 <section class="profile-modal-hidden">
   <div class="container">
-    <h1>Playlist Title</h1>
+    <div class="d-flex justify-content-between align-items-center">
+      <h1 class="m-0">Playlist Title</h1>
+      <i class="fa-solid fa-xmark"></i>
+    </div>
     <iframe id="playlist-show" style="border-radius:12px" src="https://open.spotify.com/embed/playlist/7soJCNRvS1LTHaMcT4rTqg?utm_source=generator&theme=0" width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
   </div>
 </section>
 
-  <%= render "shared/profile", playlists: @playlists %>
+<div class="overlay-hidden"></div>
+
+<div class="container">
+  <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
 </div>
+<%= render "shared/profile", playlists: @playlists %>

--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,13 +1,5 @@
 <div data-controller="profile-modal">
-  <section class="profile-modal hidden" data-profile-modal-target="modal" style="margin:0 auto">
-    <div class="modal-container">
-      <div class="d-flex justify-content-between align-items-center">
-        <h1 class="m-0">Playlist Title</h1>
-        <i class="fa-solid fa-xmark" data-action="click->profile-modal#close"></i>
-      </div>
-      <iframe id="playlist-show" style="border-radius:12px" src="https://open.spotify.com/embed/playlist/7soJCNRvS1LTHaMcT4rTqg?utm_source=generator&theme=0" width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
-    </div>
-  </section>
+
 
   <%# <div class="overlay-hidden" data-controller="profile-modal" data-profile-modal-target="overlay"></div> %>
 

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -9,7 +9,7 @@
             </div>
           </div>
           <div class="profile_card__face profile_card__face--back">
-              <iframe style="border-radius:12px;" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="100%" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+              <button class="btn-play"><i class="fa-solid fa-play"></i></button>
           </div>
         </div>
       </div>

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -14,5 +14,15 @@
         </div>
       </div>
     </div>
+
+    <section class="profile-modal hidden" data-profile-modal-target="modal" style="margin:0 auto">
+      <div class="modal-container">
+        <div class="d-flex justify-content-between align-items-center">
+          <h1 class="m-0"><%= playlist.title %></h1>
+          <span data-action="click->profile-modal#close">X</span>
+        </div>
+        <iframe id="playlist-show" style="border-radius:12px" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="1000" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+      </div>
+    </section>
   <% end %>
 </div>

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -1,7 +1,7 @@
 <div class="profile-wrapper">
   <% playlists.each do |playlist| %>
-    <div class="profile-card" data-controller="profile-card" data-action="click->profile-card#click" data-profile-modal-target="open">
-      <div class="profile-scene scene--card">
+    <div class="profile-card" data-action="click->profile-card#click">
+      <div class="profile-scene scene--card" data-action="click->profile-modal#open">
         <div class="card" data-profile-card-target="card">
           <div class="profile_card__face profile_card__face--front">
             <div class="profile-card">

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -1,6 +1,6 @@
-<div class="profile-wrapper" data-controller="profile-card">
+<div class="profile-wrapper">
   <% playlists.each do |playlist| %>
-    <div class="profile-card" data-action="click->profile-card#click">
+    <div class="profile-card" data-controller="profile-card" data-action="click->profile-card#click">
       <div class="profile-scene scene--card" data-action="click->profile-modal#open">
         <div class="card" data-profile-card-target="card">
           <div class="profile_card__face profile_card__face--front">

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -1,6 +1,6 @@
 <div class="profile-wrapper">
   <% playlists.each do |playlist| %>
-    <div class="profile-card" data-controller="profile-card" data-action="click->profile-card#click">
+    <div class="profile-card" data-controller="profile-card" data-action="click->profile-card#click" data-profile-modal-target="open">
       <div class="profile-scene scene--card">
         <div class="card" data-profile-card-target="card">
           <div class="profile_card__face profile_card__face--front">

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -1,4 +1,4 @@
-<div class="profile-wrapper">
+<div class="profile-wrapper" data-controller="profile-modal">
   <% playlists.each do |playlist| %>
     <div class="profile-card" data-controller="profile-card" data-action="click->profile-card#click">
       <div class="profile-scene scene--card" data-action="click->profile-modal#open">

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -1,4 +1,4 @@
-<div class="profile-wrapper">
+<div class="profile-wrapper" data-controller="profile-card">
   <% playlists.each do |playlist| %>
     <div class="profile-card" data-action="click->profile-card#click">
       <div class="profile-scene scene--card" data-action="click->profile-modal#open">


### PR DESCRIPTION
# Description

Changed the size of the gallery icons to be more readable on phone (changed grid from 3 to 2).
Added a neon play button to be on the back of the card instead of another Spotify iframe. 

Fixes # (issue)
https://trello.com/c/eDz0JJlN

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Screenshot A - New gallery and vault icons
<img width="369" alt="Screenshot 2023-03-26 at 1 24 46 PM" src="https://user-images.githubusercontent.com/118903492/227757085-1cb10058-310c-4c91-9d1c-dca38634e36e.png">
<img width="361" alt="Screenshot 2023-03-26 at 1 24 57 PM" src="https://user-images.githubusercontent.com/118903492/227757091-51d1895e-e141-47cf-989f-f6aa948fe07f.png">

- [x] Screenshot B - New neon play button after card is flipped (user can click on it again to bring up playlist)
<img width="352" alt="Screenshot 2023-03-26 at 1 25 39 PM" src="https://user-images.githubusercontent.com/118903492/227757114-e0cedfc7-a0e0-488e-a942-8755beea1a18.png">

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
