### PR TITLE
Playlist carousel image

### DIFF
--- a/app/assets/stylesheets/components/_event_card.scss
+++ b/app/assets/stylesheets/components/_event_card.scss
@@ -4,7 +4,7 @@
   aspect-ratio: 1 / 1;
   margin: 0;
   padding: 0.8em;
-  background-size:cover;
+  background-size: cover;
 }
 
 .event-card h1 {

--- a/app/assets/stylesheets/components/_event_card.scss
+++ b/app/assets/stylesheets/components/_event_card.scss
@@ -4,6 +4,7 @@
   aspect-ratio: 1 / 1;
   margin: 0;
   padding: 0.8em;
+  background-size:cover;
 }
 
 .event-card h1 {

--- a/app/assets/stylesheets/components/_gallery_card.scss
+++ b/app/assets/stylesheets/components/_gallery_card.scss
@@ -42,7 +42,7 @@
   padding: .6em;
   margin-top: 8%;
   height: 100%;
-  
+
   background-color: rgba(255, 255, 255, 0.074);
   border: 1px solid rgba(255, 255, 255, 0.222);
   -webkit-backdrop-filter: blur(20px);

--- a/app/views/shared/_event_image_card.html.erb
+++ b/app/views/shared/_event_image_card.html.erb
@@ -1,4 +1,4 @@
-<div class="event-card" style="background-image: linear-gradient(rgba(0,0,0,.5), rgba(0,0,0,0) 60%), url('<%= cl_image_path playlist.photo.key, crop: :fill %>')">
+<div class="event-card" style="background-image: linear-gradient(rgba(0,0,0,.5), rgba(0,0,0,0) 60%), url('<%= cl_image_path playlist.photo.key, crop: :fit %>')">
   <h1><%= playlist.title %></h1>
   <%= link_to "", playlist_path(playlist), class: "event-card-link" %>
 </div>


### PR DESCRIPTION
# Description

Changes background size so that playlist carousel on home page displays full image rather than cropped version

Fixes # (issue)
https://trello.com/c/xhU6l4Ye

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Screenshot A
<img width="329" alt="Screenshot 2023-03-27 at 11 34 34 AM" src="https://user-images.githubusercontent.com/99415923/227834672-342d6f5c-c216-48c8-9360-683529624bab.png">


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
