### PR TITLE
Adds functionality to upload generated image to spotify

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -36,11 +36,9 @@ class PlaylistsController < ApplicationController
     else
       # add tracks and replace image to spotify playlist
       @spotify_playlist.add_tracks!(@song_uris)
-
-      # @spotify_playlist.replace_image!(playlist_params[:photo], playlist_params[:photo].content_type)
-
+      
       @ss_playlist = Playlist.new(title: playlist_params[:title], user: current_user, spotify_id: @spotify_playlist.id)
-
+      
       # Using OpenAI gem to generate image from the Song instance object.
       # Here, we use the first song in the playlist to generate the image.
       require "open-uri"
@@ -48,6 +46,11 @@ class PlaylistsController < ApplicationController
       @ss_playlist.photo.attach(io: playlist_image, filename: "#{@ss_playlist.title}.png", content_type: "image/png")
 
       if @ss_playlist.save!
+        # As Spotify only accepts jpeg in Base64 string format, we would need to use Cloudinary to convert the uploaded png from OpenAI into jpeg.
+        # Then, we would need to use strict_encode64.
+        jpeg_image = URI.open("#{@ss_playlist.photo.url[...-4]}.jpeg") { |io| io.read }
+        @spotify_playlist.replace_image!(Base64.strict_encode64(jpeg_image), 'image/jpeg')
+        
         redirect_to playlist_path(@ss_playlist)
       else
         render :new, status: :unprocessable_entity

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,7 @@
 require 'rspotify/oauth'
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :spotify, ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_SECRET"], scope: 'user-read-email user-read-private user-library-read user-library-modify playlist-modify-public playlist-modify-private streaming'
+  provider :spotify, ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_SECRET"], scope: 'user-read-email user-read-private user-library-read user-library-modify playlist-modify-public playlist-modify-private streaming ugc-image-upload'
 end
 
 OmniAuth.config.allowed_request_methods = [:post, :get]


### PR DESCRIPTION
# Description
- fetch the uploaded playlist photo from Cloudinary in .jpeg form, as required for uploading to spotify

Fixes # (issue)
[https://trello.com/c/pdFklTzK](https://trello.com/c/pdFklTzK)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [ ] Playlist show 
![image](https://user-images.githubusercontent.com/81938708/227882209-73dbfbc0-4a27-4db0-860a-7dcad3e6fb39.png)

# Checklist:
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
