### PR TITLE
Bugfix tempo slider out of bounds

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -31,6 +31,8 @@ class EventsController < ApplicationController
     if @event.update(event_params)
       redirect_to new_event_playlist_path(@event)
     else
+      @event.min_tempo = (@event.min_tempo / 220)
+      @event.max_tempo = (@event.max_tempo / 220)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,6 +11,8 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to new_event_playlist_path(@event)
     else
+      @event.min_tempo = (@event.min_tempo / 220)
+      @event.max_tempo = (@event.max_tempo / 220)
       render :new, status: :unprocessable_entity
     end
   end


### PR DESCRIPTION
# Description
- bugfix for the event slider (tempo is out of bound when title is not entered)

Fixes # (issue)
[https://trello.com/c/0aOPRDHq](https://trello.com/c/0aOPRDHq)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
- [x] New Event Page
![image](https://user-images.githubusercontent.com/81938708/227958422-b037ffe0-d2f9-49a2-a986-88c908c856cf.png)

- [x] Edit Event Page
![image](https://user-images.githubusercontent.com/81938708/227958569-cefe9669-8061-42ec-9b39-50bf37c82cf3.png)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
