### PR TITLE
Bugfix event card carousel misaligned

### DIFF
--- a/app/assets/stylesheets/components/_carousel.scss
+++ b/app/assets/stylesheets/components/_carousel.scss
@@ -2,6 +2,8 @@
 
 .carousel {
   padding: 1.2rem 0;
+  max-width: 900px;
+  margin: 0 auto;
 }
   
 .carousel-cell {

--- a/app/assets/stylesheets/pages/_vault.scss
+++ b/app/assets/stylesheets/pages/_vault.scss
@@ -7,6 +7,8 @@
 .event-slide {
   padding: 1rem 0;
   max-height: 10rem;
+  max-width: 900px;
+  margin: 0 auto;
 }
   
 .event-cell {


### PR DESCRIPTION
# Description
- bugfix for event card carousel and playlist card misaligned, especially when the number of card is less than 3.

Fixes # (issue)
[https://trello.com/c/1GRNrDJw](https://trello.com/c/1GRNrDJw)

## Type of change
- limit the card displayed to 3 in the carousel
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Home Page
![image](https://user-images.githubusercontent.com/81938708/227964989-b2cc2814-8c07-4835-823c-58e0a07e098e.png)

- [x] Vault
![image](https://user-images.githubusercontent.com/81938708/227965094-3ef1d734-ec0d-4dca-93ff-94ddf84bfe44.png)


# Checklist:
- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
