### PR TITLE
removes the border of the thumb in the event form in Mozilla browser

### DIFF
--- a/app/assets/stylesheets/components/_slider.scss
+++ b/app/assets/stylesheets/components/_slider.scss
@@ -58,18 +58,22 @@ $thumb-border-color: $gray;
 }
 
 .range-input .min::-webkit-slider-thumb {
+  border: 0;
   background-color: $cold-color;
 }
 
 .range-input .min::-moz-range-thumb {
+  border: 0;
   background-color: $cold-color;
 }
 
 .range-input .max::-webkit-slider-thumb {
+  border: 0;
   background-color: $hot-color;
 }
 
 .range-input .max::-moz-range-thumb {
+  border: 0;
   background-color: $hot-color;
 }
 
@@ -95,6 +99,7 @@ $thumb-border-color: $gray;
   height: $thumb-height;
   width: $thumb-height;
   border-radius: 50%;
+  border: 0;
   background-color: $medium-color;
   cursor: pointer;
   -webkit-appearance: none;
@@ -116,6 +121,7 @@ $thumb-border-color: $gray;
   height: $thumb-height;
   width: $thumb-height;
   border-radius: 50%;
+  border: 0;
   background-color: $medium-color;
   cursor: pointer;
 }
@@ -142,6 +148,7 @@ $thumb-border-color: $gray;
   width: $thumb-height;
   border-radius: 50%;
   background-color: $medium-color;
+  border: 0;
   cursor: pointer;
 }
 .time-slider:focus::-ms-fill-lower {


### PR DESCRIPTION
# Description
- Bugfix for the grey border at the slider thumb in the event form in Mozilla Firefox browser

Fixes # (issue)
[https://trello.com/c/FhQots9Y](https://trello.com/c/FhQots9Y)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?
- [x] Event form in Mozilla Browser
![image](https://user-images.githubusercontent.com/81938708/228120747-aab444ac-f361-4c40-9a64-6a16d2be22f5.png)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
