### PR TITLE
Bugfix: Modal position fix

### DIFF
--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -13,7 +13,9 @@
   position: fixed;
   top:10%;
   bottom:10%;
-  margin:auto;
+  left: 5%;
+  min-width: 90%;
+  margin:0 auto;
 
   background-color: rgba(255, 255, 255, 0.074);
   border: 1px solid rgba(255, 255, 255, 0.222);

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -1,4 +1,5 @@
 .modal-container {
+  position: relative;
   width: 85%;
   margin: 0 auto;
   margin-top: 5%;
@@ -9,11 +10,10 @@
   align-items: center;
   background-color: $light-gray;
   z-index: 2;
-  position: absolute;
-  top: 15%;
-  left: 0;
-  right: 0;
-  margin: auto;
+  position: fixed;
+  top:10%;
+  bottom:10%;
+  margin:auto;
 
   background-color: rgba(255, 255, 255, 0.074);
   border: 1px solid rgba(255, 255, 255, 0.222);

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -1,8 +1,7 @@
 .modal-container {
   position: relative;
   width: 85%;
-  margin: 0 auto;
-  margin-top: 5%;
+  margin: 2% auto;
 }
 
 .profile-modal {

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -5,9 +5,10 @@ export default class extends Controller {
   static targets = ["modal", "overlay", "share"]
 
   open() {
-    setTimeout(() => {
+    setTimeout((event) => {
       this.modalTarget.classList.remove("hidden")
     }, 500);
+    console.log(this.event);
   }
 
   close() {


### PR DESCRIPTION
# Description

Bugfix: Makes the modal for the profile card appear in the centre of the screen even if the user is scrolled down. Modal will always appear in the centre of the screen.

Edits: The border and position of the modal to be responsive to desktop view.

Fixes # (issue)
https://trello.com/c/LiMHnuqN

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Screenshot A - Modal will appear in the centre of the screen even if scrolled down and modal will move with the user as they try to scroll. Even when clicking the last playlist, modal will appear at centre screen.

<img width="353" alt="Screenshot 2023-03-28 at 11 58 47 AM" src="https://user-images.githubusercontent.com/118903492/228124556-364deb9a-186a-4af9-8211-ecc1725dd409.png">

<img width="351" alt="Screenshot 2023-03-28 at 11 59 01 AM" src="https://user-images.githubusercontent.com/118903492/228124593-bf16830e-d6fe-456b-8525-fe8f0422fc32.png">

- [x] Screenshot B - Modal for desktop view
<img width="1180" alt="Screenshot 2023-03-28 at 11 59 46 AM" src="https://user-images.githubusercontent.com/118903492/228124710-ab726392-622a-4d38-b40f-13c77ec4b515.png">

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
