### PR TITLE
Default no playlist

### DIFF
--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -8,4 +8,9 @@
     <h2><%= @user.nickname.capitalize %>'s Gallery</h2>
   </div>
 </div>
-<%= render "shared/profile", playlists: @playlists.where(is_shared: true) %>
+
+<% if @playlists.where(is_shared: true).empty?  %>
+  <%= render "shared/default_gallery" %>
+<% else %>
+  <%= render "shared/profile", playlists: @playlists.where(is_shared: true) %>
+<% end %>

--- a/app/views/shared/_default_gallery.html.erb
+++ b/app/views/shared/_default_gallery.html.erb
@@ -1,0 +1,8 @@
+<div class="container">
+  <div class="d-flex flex-column" style="margin-top: 50px; !important">
+    <p class="text-center">No shared playlists</p>
+    <p class="text-center" style="font-style: italic; font-size: small;">Create a new playlist or share an existing playlist from your vault!</p>
+  </div>
+</div>
+
+<button class="btn create-btn">Create a new playlist</button>

--- a/app/views/shared/_default_profile.html.erb
+++ b/app/views/shared/_default_profile.html.erb
@@ -1,0 +1,4 @@
+<div class="d-flex flex-column" style="margin-top: 50px; !important">
+  <p class="text-center">You have no playlist at the moment</p>
+  <button class="btn create-btn">Create a new playlist</button>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,5 +13,9 @@
 </div>
 <div class="vault-bottom">
   <h2 class="text-center">Your Vault</h2>
-  <%= render "shared/profile", playlists: @playlists.where(is_shared: false) %>
+  <% if @playlists.where(is_shared: false).empty? %>
+    <%= render "shared/default_profile" %>
+  <% else %>
+    <%= render "shared/profile", playlists: @playlists.where(is_shared: false) %>
+  <% end %>
 </div>


### PR DESCRIPTION
# Description

Adds message and call-to-action for users for both vault and gallery if they have no playlist to show.

Fixes # (issue)
https://trello.com/c/bRt7TKye

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Screenshot A - Vault when there are playlist and when there is no playlist
<img width="354" alt="Screenshot 2023-03-28 at 12 43 18 PM" src="https://user-images.githubusercontent.com/118903492/228130423-4338b827-b5cc-46bb-ad35-e4a2669b40c9.png">
<img width="352" alt="Screenshot 2023-03-28 at 12 44 34 PM" src="https://user-images.githubusercontent.com/118903492/228130584-bfe6bc1a-02eb-40db-8f95-1c3ed18b9dcf.png">

- [x] Screenshot B - Gallery when there are playlists and when there are no playlist
<img width="351" alt="Screenshot 2023-03-28 at 12 44 47 PM" src="https://user-images.githubusercontent.com/118903492/228130608-6fc64330-10c1-460d-b267-231b97b31247.png">
<img width="355" alt="Screenshot 2023-03-28 at 12 43 37 PM" src="https://user-images.githubusercontent.com/118903492/228130458-8ea0e26c-8a58-45f7-bcab-04f2806c1419.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
