### PR TITLE
Vault gallery bugfix

### DIFF
--- a/app/views/shared/_default_gallery.html.erb
+++ b/app/views/shared/_default_gallery.html.erb
@@ -1,9 +1,19 @@
-<div class="container">
+<% if current_user.id == @playlists.first.user_id %>
+  <div class="container">
   <div class="d-flex flex-column" style="margin-top: 50px; !important">
     <p class="text-center">No shared playlists</p>
     <p class="text-center" style="font-style: italic; font-size: small;">Create a new playlist or share an existing playlist from your vault!</p>
   </div>
-</div>
-<%= link_to new_event_path, class:"text-decoration-none" do %>
+  </div>
+  <%= link_to new_event_path, class:"text-decoration-none" do %>
   <button class="btn create-btn">Create a new playlist</button>
+  <% end %>
+
+  <% else %>
+
+  <div class="container">
+  <div class="d-flex flex-column" style="margin-top: 50px; !important">
+    <p class="text-center"><%= @playlists.first.user.nickname %> has no shared playlists</p>
+  </div>
+
 <% end %>

--- a/app/views/shared/_default_gallery.html.erb
+++ b/app/views/shared/_default_gallery.html.erb
@@ -4,5 +4,6 @@
     <p class="text-center" style="font-style: italic; font-size: small;">Create a new playlist or share an existing playlist from your vault!</p>
   </div>
 </div>
-
-<button class="btn create-btn">Create a new playlist</button>
+<%= link_to new_event_path, class:"text-decoration-none" do %>
+  <button class="btn create-btn">Create a new playlist</button>
+<% end %>

--- a/app/views/shared/_default_profile.html.erb
+++ b/app/views/shared/_default_profile.html.erb
@@ -1,4 +1,6 @@
 <div class="d-flex flex-column" style="margin-top: 50px; !important">
   <p class="text-center">You have no playlist at the moment</p>
-  <button class="btn create-btn">Create a new playlist</button>
+  <%= link_to new_event_path, class:"text-decoration-none" do %>
+    <button class="btn create-btn">Create a new playlist</button>
+  <% end %>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -14,7 +14,7 @@
 <div class="vault-bottom">
   <h2 class="text-center">Your Vault</h2>
   <% if @playlists.empty? %>
-    <%= render "shared/default_profile" %>
+    <%= render "shared/default_profile", user:  %>
   <% else %>
     <%= render "shared/profile", playlists: @playlists %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,9 +13,9 @@
 </div>
 <div class="vault-bottom">
   <h2 class="text-center">Your Vault</h2>
-  <% if @playlists.where(is_shared: false).empty? %>
+  <% if @playlists.empty? %>
     <%= render "shared/default_profile" %>
   <% else %>
-    <%= render "shared/profile", playlists: @playlists.where(is_shared: false) %>
+    <%= render "shared/profile", playlists: @playlists %>
   <% end %>
 </div>


### PR DESCRIPTION
# Description

Bugfixes:

- Change Vault to show all playlist (shared to unshared)
- Add path routes for default buttons for gallery and vault
- Add logic for default buttons to only appear if gallery belongs to current user

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Screenshot A - Change Vault to show all playlist (shared to unshared)
<img width="379" alt="Screenshot 2023-03-28 at 4 14 58 PM" src="https://user-images.githubusercontent.com/118903492/228172809-bc5ec708-00fa-4df3-a95a-8621f130b6c5.png">

- [ ] Screenshot B - Add path routes for default buttons for gallery and vault
<img width="430" alt="Screenshot 2023-03-28 at 4 16 31 PM" src="https://user-images.githubusercontent.com/118903492/228173223-345c80f0-2138-4f3b-94fe-7de4d6bf0e14.png">
<img width="446" alt="Screenshot 2023-03-28 at 4 16 43 PM" src="https://user-images.githubusercontent.com/118903492/228173312-b23e54d3-3a26-409c-8bca-9f33549649a6.png">

- [ ] Screenshot C - Add logic for default buttons to only appear if gallery belongs to current user
<img width="400" alt="Screenshot 2023-03-28 at 4 17 06 PM" src="https://user-images.githubusercontent.com/118903492/228173505-8babd208-8d9e-4a3b-8f74-a633e7499ffd.png">
<img width="402" alt="Screenshot 2023-03-28 at 4 18 17 PM" src="https://user-images.githubusercontent.com/118903492/228173862-d5feaa6d-71ec-417a-bea3-917cb82e520e.png">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
