### PR TITLE
Edit to use @user.id instead of playlist.user

### DIFF
--- a/app/views/shared/_default_gallery.html.erb
+++ b/app/views/shared/_default_gallery.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.id == @playlists.first.user_id %>
+<% if current_user.id == @user.id %>
   <div class="container">
   <div class="d-flex flex-column" style="margin-top: 50px; !important">
     <p class="text-center">No shared playlists</p>


### PR DESCRIPTION
# Description

Bugfix: When new user signs up, gallery will no longer throw out an error page. 

Fixes # (issue)
https://trello.com/c/W57VpjdV

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Screenshot A - User's own gallery upon sign up
<img width="378" alt="Screenshot 2023-03-28 at 4 53 47 PM" src="https://user-images.githubusercontent.com/118903492/228183491-7b7167b2-0894-490c-891c-84c79f23996b.png">

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
