### PR TITLE
Move spinner and refactor playlist new into partials

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -36,12 +36,6 @@ class PlaylistsController < ApplicationController
     )
 
     if @ss_playlist.save!
-      # As Spotify only accepts jpeg in Base64 string format, we would need to use Cloudinary to convert the uploaded png from OpenAI into jpeg.
-
-      # jpeg_image = URI.open("#{@ss_playlist.photo.url[...-4]}.jpeg") { |io| io.read }
-
-      # # replace spotify playlist image with AI generated one
-      # spotify_playlist.replace_image!(Base64.strict_encode64(jpeg_image), 'image/jpeg')
       update_spotify_playlist_image(@ss_playlist, spotify_playlist)
 
       redirect_to playlist_path(@ss_playlist)

--- a/app/javascript/controllers/image_creation_controller.js
+++ b/app/javascript/controllers/image_creation_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
     "createPlaylistButton",
     "photo",
     "title",
+    "regenerateButton",
   ];
 
   static values = {
@@ -22,13 +23,15 @@ export default class extends Controller {
     await this.generateImage();
 
     this.playlistTarget.classList.add("d-none");
-    this.imageWrapperTarget.classList.remove("d-none");
+    this.imageTarget.classList.remove("d-none");
+    this.regenerateButtonTarget.classList.remove("d-none");
     this.generateImageButtonTarget.classList.add("d-none");
     this.createPlaylistButtonTarget.classList.remove("d-none");
   }
 
   generateImage() {
-    this.imageWrapperTarget.innerHTML = "<div style='my-4'>Loading...</div>";
+    this.imageTarget.innerHTML =
+      "<div class='playlist-loader'></div><div>Generating AI Art...</div>";
 
     fetch(`/events/${this.eventidValue}/image`, {
       headers: {
@@ -37,10 +40,8 @@ export default class extends Controller {
     })
       .then((res) => res.text())
       .then((url) => {
-        this.imageWrapperTarget.innerHTML = `<img src="${url}" />`;
-
+        this.imageTarget.innerHTML = `<img src="${url}" /><div style='cursor: pointer' class='d-flex justify-content-center py-4' data-image-creation-target='regenerateButton'><i class='fa-solid fa-arrows-rotate' data-action='click->image-creation#generateImage'></i></div>`;
         this.photoTarget.value = url;
-
       });
   }
 }

--- a/app/javascript/controllers/image_creation_controller.js
+++ b/app/javascript/controllers/image_creation_controller.js
@@ -9,7 +9,6 @@ export default class extends Controller {
     "generateImageButton",
     "createPlaylistButton",
     "photo",
-    "title",
     "regenerateButton",
   ];
 
@@ -20,28 +19,33 @@ export default class extends Controller {
   connect() {}
 
   async showImage() {
-    await this.generateImage();
-
-    this.playlistTarget.classList.add("d-none");
     this.imageTarget.classList.remove("d-none");
-    this.regenerateButtonTarget.classList.remove("d-none");
+    this.playlistTarget.classList.add("d-none");
     this.generateImageButtonTarget.classList.add("d-none");
+    await this.generateImage();
+    this.regenerateButtonTarget.classList.remove("d-none");
     this.createPlaylistButtonTarget.classList.remove("d-none");
   }
 
   generateImage() {
-    this.imageTarget.innerHTML =
-      "<div class='playlist-loader'></div><div>Generating AI Art...</div>";
+    return new Promise((resolve, reject) => {
+      this.imageTarget.innerHTML =
+        "<div class='playlist-loader'></div><div>Generating AI Art...</div>";
 
-    fetch(`/events/${this.eventidValue}/image`, {
-      headers: {
-        Accept: "text/plain",
-      },
-    })
-      .then((res) => res.text())
-      .then((url) => {
-        this.imageTarget.innerHTML = `<img src="${url}" /><div style='cursor: pointer' class='d-flex justify-content-center py-4' data-image-creation-target='regenerateButton'><i class='fa-solid fa-arrows-rotate' data-action='click->image-creation#generateImage'></i></div>`;
-        this.photoTarget.value = url;
-      });
+      fetch(`/events/${this.eventidValue}/image`, {
+        headers: {
+          Accept: "text/plain",
+        },
+      })
+        .then((res) => res.text())
+        .then((url) => {
+          this.imageTarget.innerHTML = `<img src="${url}" />`;
+          this.photoTarget.value = url;
+          resolve();
+        })
+        .catch((error) => {
+          reject(error);
+        });
+    });
   }
 }

--- a/app/services/generate_image_service.rb
+++ b/app/services/generate_image_service.rb
@@ -10,6 +10,7 @@ class GenerateImageService
     # Generate image and returns image url.
     client = OpenAI::Client.new
     image_response = client.images.generate(parameters: { prompt: "#{prompt}, #{mood_descriptors(event).sample(2).join(', ')}, in the art style of #{art_styles.sample}", size: "256x256" })
+    # image_response = client.images.generate(parameters: { prompt: "#{prompt}, #{mood_descriptors(event).sample(2).join(', ')}, in the art style of #{art_styles.sample}", size: "256x256" })
 
     img_res = image_response.dig('data', 0, 'url')
   end
@@ -32,7 +33,7 @@ class GenerateImageService
 
   # Private method to generate prompt from the Song instance object.
   def self.generate_prompt(song)
-    query = "Return a string of the meaning of the song #{song.name} by #{song.artist}. Limit to 10 words."
+    query = "Return the mood of the song #{song.name} by #{song.artist} in three words."
 
     client = OpenAI::Client.new
     response = client.chat(

--- a/app/services/make_spotify_playlist_service.rb
+++ b/app/services/make_spotify_playlist_service.rb
@@ -1,21 +1,16 @@
 class MakeSpotifyPlaylistService
   def self.call(event:, current_user:, playlist_params:, image_url:)
-
+    playlist_image = URI.open(image_url)
     # @event, current_user, @ss_playlist
     songs, song_uris = event.filter_songs(current_user)
-
     # make empty playlist in spotify playlist
     spotify_user = current_user.spotify_user
     spotify_playlist = spotify_user.create_playlist!(playlist_params[:title])
-
     # add tracks to spotify
     spotify_playlist.add_tracks!(song_uris)
 
     # add playlist to our DB
     ss_playlist = Playlist.new(title: playlist_params[:title], user: current_user, spotify_id: spotify_playlist.id)
-
-   
-    playlist_image = URI.open(image_url)
 
     # attaching AI image to our DB
     ss_playlist.photo.attach(io: playlist_image, filename: "#{ss_playlist.title}.png", content_type: "image/png")

--- a/app/views/playlists/_generate_playlist_round_spinner.html.erb
+++ b/app/views/playlists/_generate_playlist_round_spinner.html.erb
@@ -1,0 +1,3 @@
+<span class="loader"></span>
+<p>&nbsp;</p>
+<p>Finalising Your Playlist</p>

--- a/app/views/playlists/_generate_playlist_spinner.html.erb
+++ b/app/views/playlists/_generate_playlist_spinner.html.erb
@@ -11,13 +11,14 @@
     <p>G</p>
   </div>
   <div class="spinner">
+    <p>P</p>
+    <p>L</p>
     <p>A</p>
+    <p>Y</p>
+    <p>L</p>
     <p>I</p>
-    <p>&nbsp</p>
-    <p>A</p>
-    <p>R</p>
+    <p>S</p>
     <p>T</p>
-    <p>.</p>
     <p>.</p>
     <p>.</p>
   </div>

--- a/app/views/playlists/_image_display.html.erb
+++ b/app/views/playlists/_image_display.html.erb
@@ -1,0 +1,8 @@
+<div>
+  <div data-image-creation-target='image' class='text-center d-none'>
+    <img src="" alt="">
+  </div>
+  <div style='cursor: pointer' class='d-flex d-none justify-content-center py-4' data-image-creation-target='regenerateButton'>
+    <i class='fa-solid fa-arrows-rotate' data-action='click->image-creation#generateImage'></i>
+  </div>
+</div>

--- a/app/views/playlists/_playlist_creation_form.html.erb
+++ b/app/views/playlists/_playlist_creation_form.html.erb
@@ -1,0 +1,7 @@
+<div class="mb-5 d-none" data-image-creation-target='createPlaylistButton'>
+  <%= simple_form_for [@event, @playlist], defaults: { required: false } do |f| %>
+    <%= f.input :photo, as: :hidden, value: "", input_html: { data: {image_creation_target: "photo"} } %>
+    <%= f.input :title, as: :hidden, input_html: { value: @event.title || 'My Playlist', class: "new-playlist-form", readonly: true, data: {image_creation_target: "title"} } %>
+    <%= f.button :submit,"Create Playlist", class: "btn create-btn", data: {bs_toggle: "modal", bs_target: "#playlistSpinnerModal"} %>
+  <% end %>
+</div>

--- a/app/views/playlists/_spinner_modal.html.erb
+++ b/app/views/playlists/_spinner_modal.html.erb
@@ -1,0 +1,7 @@
+<div class="modal" id="playlistSpinnerModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
+  <div class="modal-dialog modal-fullscreen">
+    <div class="modal-content d-flex justify-content-center align-items-center"  style='background: black; opacity: 0.9'>
+      <%= render 'generate_playlist_round_spinner' %>
+    </div>
+  </div>
+</div>

--- a/app/views/playlists/_webplayer.html.erb
+++ b/app/views/playlists/_webplayer.html.erb
@@ -1,0 +1,16 @@
+<div class="sdk-container d-flex justify-content-center align-items-start flex-wrap gap-1" data-image-creation-target='playlist'>
+  <div id="embed-iframe"></div>
+  <div class="flex-grow-1 episodes-container">
+    <ul id="episodes" class="list-unstyled">
+      <div class="list-items-container">
+        <% @songs.each do |song| %>
+          <li class="episodes">
+            <button class="btn episode" data-spotify-id=<%= song.uri %>>
+                  <strong><%= song.name %></strong> - <%= song.artist %>
+            </button>
+          </li>
+        <% end %>
+      </div>
+    </ul>
+  </div>
+</div>

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -44,15 +44,15 @@
       </div>
     </div>
     <%# image display %>
-    <div data-image-creation-target='imageWrapper' class='text-center d-none'>
-      <img src="" data-image-creation-target="image" alt="">
+    <div>
+      <div data-image-creation-target='image' class='text-center d-none'>
+        <img src="" alt="">
+      </div>
     </div>
-    
     <%# refresh button %>
-    <div class="d-flex justify-content-center py-4">
+    <%# <div class="d-flex justify-content-center py-4 d-none" data-image-creation-target="regenerateButton">
       <i class="fa-solid fa-arrows-rotate" data-action="click->image-creation#generateImage"></i>
-    </div>
-    
+    </div> %>
     <%# Create playlist button %>
     <div class="mb-5">
       <%= simple_form_for [@event, @playlist], defaults: { required: false } do |f| %>

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -16,58 +16,20 @@
   reloadPage();
 </script>
 <div class="container" id="new-playlist" data-controller='image-creation' data-image-creation-eventid-value="<%= @event.id %>">
-  <h1>NEW PLAYLIST PREVIEW</h1>
+  <h1>New Playlist Preview</h1>
   <div id="first-song" value="<%= @song_uris.first %>"></div>
   <p><i class="fa-solid fa-chevron-left"></i> <%= link_to 'Edit filters', edit_event_path(@event)%></p>
   <%# Generate image button %>
   <div class="mb-5">
     <div class='btn create-btn' data-action='click->image-creation#showImage' data-image-creation-target='generateImageButton'>Generate Image</div>
   </div>
-  <%# playlist sdk %>
   <% if @songs.count == 0 %>
     <h2 class="mt-5">Oopsie Daisy! Your library does not contain songs which match your filters.</h2>
   <% else %>
-    <div class="sdk-container d-flex justify-content-center align-items-start flex-wrap gap-1" data-image-creation-target='playlist'>
-      <div id="embed-iframe"></div>
-      <div class="flex-grow-1 episodes-container">
-        <ul id="episodes" class="list-unstyled">
-          <div class="list-items-container">
-            <% @songs.each do |song| %>
-              <li class="episodes">
-                <button class="btn episode" data-spotify-id=<%= song.uri %>>
-                  <strong><%= song.name %></strong> - <%= song.artist %>
-                </button>
-              </li>
-            <% end %>
-          </div>
-        </ul>
-      </div>
-    </div>
-    <%# image display %>
-    <div>
-      <div data-image-creation-target='image' class='text-center d-none'>
-        <img src="" alt="">
-      </div>
-    </div>
-    <%# refresh button %>
-    <%# <div class="d-flex justify-content-center py-4 d-none" data-image-creation-target="regenerateButton">
-      <i class="fa-solid fa-arrows-rotate" data-action="click->image-creation#generateImage"></i>
-    </div> %>
-    <%# Create playlist button %>
-    <div class="mb-5">
-      <%= simple_form_for [@event, @playlist], defaults: { required: false } do |f| %>
-        <%= f.input :photo, as: :hidden, value: "", input_html: { data: {image_creation_target: "photo"} } %>
-        <%= f.input :title, as: :hidden, input_html: { value: @event.title || 'My Playlist', class: "new-playlist-form", readonly: true, data: {image_creation_target: "title"} } %>
-        <%= f.button :submit,"Create Playlist", class: "d-none btn create-btn", data: {image_creation_target: "createPlaylistButton", bs_toggle: "modal", bs_target: "#playlistSpinnerModal"} %>
-      <% end %>
-    </div>
+    <%= render 'webplayer' %>
+    <%= render 'image_display' %>
+    <%= render 'playlist_creation_form' %>
   <% end %>
 </div>
 <%# Spinner modal %>
-<div class="modal" id="playlistSpinnerModal" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
-  <div class="modal-dialog modal-fullscreen">
-    <div class="modal-content d-flex justify-content-center align-items-center"  style='background: black; opacity: 0.9'>
-      <%= render 'generate_playlist_spinner' %>
-    </div>
-  </div>
-</div>
+<%= render 'spinner_modal' %>


### PR DESCRIPTION
# Description
Further work on playlist new page:
- Updates spinners to match new flow of image generation before playlist confirmation.
- Refactors some of the playlist new view into partials.
- Further cleans up playlists controller and service objects

Fixes # (issue)
https://trello.com/c/iuNJ0Uts

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] on playlist new page
<img width="341" alt="Screenshot 2023-03-28 at 8 08 12 PM" src="https://user-images.githubusercontent.com/99415923/228231343-6f88b574-cf19-4021-afac-ee4be4a8784e.png">


- [x] on hitting create playlist
<img width="397" alt="Screenshot 2023-03-28 at 8 08 22 PM" src="https://user-images.githubusercontent.com/99415923/228231361-f11b6b3e-ce06-4f45-914b-b04d91b55f4c.png"> 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
