### PR TITLE
Centers Spotify iframe to the centre of the modal (for desktop)

### DIFF
--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -42,7 +42,9 @@
                  data-action="click->profile-modal#close"></i>
             </div>
           </div>
-          <iframe id="playlist-show" style="border-radius:12px" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="600" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+          <div class="d-flex justify-content-center">
+            <iframe id="playlist-show" style="border-radius:12px;" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="600" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
# Description

Centers the Spotify iframe to the centre of the modal for desktop view. 

Spotify iframe only has a max-width of 800 so we can't stretch it out to fit the whole modal.

Fixes # (issue)
https://trello.com/c/4riMgTfv

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Screenshot A - In mobile
<img width="367" alt="Screenshot 2023-03-29 at 10 50 06 AM" src="https://user-images.githubusercontent.com/118903492/228414013-a82d784b-552d-4667-8230-844ead638be0.png">

- [ ] Screenshot B - In desktop
<img width="1002" alt="Screenshot 2023-03-29 at 10 50 59 AM" src="https://user-images.githubusercontent.com/118903492/228414139-11f871e0-dbe3-411b-90ed-fbb262e497fe.png">

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
