### PR TITLE
Change the button to have fewer words

### DIFF
--- a/app/views/shared/_default_gallery.html.erb
+++ b/app/views/shared/_default_gallery.html.erb
@@ -6,7 +6,7 @@
   </div>
   </div>
   <%= link_to new_event_path, class:"text-decoration-none" do %>
-  <button class="btn create-btn">Create a new playlist</button>
+  <button class="btn create-btn">Create playlist</button>
   <% end %>
 
   <% else %>

--- a/app/views/shared/_default_profile.html.erb
+++ b/app/views/shared/_default_profile.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex flex-column" style="margin-top: 50px; !important">
   <p class="text-center">You have no playlist at the moment</p>
   <%= link_to new_event_path, class:"text-decoration-none" do %>
-    <button class="btn create-btn">Create a new playlist</button>
+    <button class="btn create-btn">Create playlist</button>
   <% end %>
 </div>


### PR DESCRIPTION
# Description

Bug-fix: changed the default buttons to be in one line instead of multiple lines on mobile

Fixes # (issue)
https://trello.com/c/PWwkoI6p

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Screenshot A - Gallery default page if no playlist 
<img width="361" alt="Screenshot 2023-03-29 at 1 35 54 PM" src="https://user-images.githubusercontent.com/118903492/228436421-15a068fd-2aa2-46fb-a481-51fc94e3fa4e.png">

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
