### PR TITLE
Hide delete button if playlist doesn't belong to user

### DIFF
--- a/app/views/shared/_default_gallery.html.erb
+++ b/app/views/shared/_default_gallery.html.erb
@@ -6,7 +6,7 @@
   </div>
   </div>
   <%= link_to new_event_path, class:"text-decoration-none" do %>
-  <button class="btn create-btn">Create a new playlist</button>
+  <button class="btn create-btn">Create playlist</button>
   <% end %>
 
   <% else %>

--- a/app/views/shared/_default_profile.html.erb
+++ b/app/views/shared/_default_profile.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex flex-column" style="margin-top: 50px; !important">
   <p class="text-center">You have no playlist at the moment</p>
   <%= link_to new_event_path, class:"text-decoration-none" do %>
-    <button class="btn create-btn">Create a new playlist</button>
+    <button class="btn create-btn">Create playlist</button>
   <% end %>
 </div>

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -35,8 +35,10 @@
               </div>
             <% end %>
             <div class='d-flex align-items-center gap-3'>
-              <%= link_to playlist_path(playlist), class:'text-decoration-none', data: {action: "click->profile-modal#close", turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
-                <i class="text-white fa-solid fa-trash"></i>
+              <div class=<%= playlist.user_id == current_user.id ? "" : "d-none" %>>
+                <%= link_to playlist_path(playlist), class:'text-decoration-none', data: {action: "click->profile-modal#close", turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
+                  <i class="text-white fa-solid fa-trash"></i>
+              </div>
               <% end %>
               <i class="fa-solid fa-xmark"
                  data-action="click->profile-modal#close"></i>


### PR DESCRIPTION
# Description

Hides playlist delete button if the playlist shown does not belong to the current user.

Fixes # (issue)
https://trello.com/c/o9jLU4qG

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Screenshot A - Playlist belongs to user
<img width="334" alt="Screenshot 2023-03-29 at 1 57 48 PM" src="https://user-images.githubusercontent.com/118903492/228439916-e0d7cadd-6d03-4ee2-865c-1bb1b96867e1.png">

- [ ] Screenshot B - Playlist does not belong to user
<img width="320" alt="Screenshot 2023-03-29 at 1 57 12 PM" src="https://user-images.githubusercontent.com/118903492/228439822-8039c073-7d4f-4950-9446-558b2e01dedb.png">


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
