### PR TITLE
Shifts the sleep to after ss_playlist is saved

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -36,7 +36,9 @@ class PlaylistsController < ApplicationController
     )
 
     if @ss_playlist.save!
+      # sleep delay to allow Cloudinary to update the uploaded image, and Spotify to create and add songs to playlist.
       sleep(5)
+      
       update_spotify_playlist_image(@ss_playlist, spotify_playlist)
 
       redirect_to playlist_path(@ss_playlist)

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -36,6 +36,7 @@ class PlaylistsController < ApplicationController
     )
 
     if @ss_playlist.save!
+      sleep(5)
       update_spotify_playlist_image(@ss_playlist, spotify_playlist)
 
       redirect_to playlist_path(@ss_playlist)

--- a/app/services/make_spotify_playlist_service.rb
+++ b/app/services/make_spotify_playlist_service.rb
@@ -14,7 +14,6 @@ class MakeSpotifyPlaylistService
 
     # attaching AI image to our DB
     ss_playlist.photo.attach(io: playlist_image, filename: "#{ss_playlist.title}.png", content_type: "image/png")
-    sleep(5)
     return [ss_playlist, spotify_playlist]
   end
 end


### PR DESCRIPTION
# Description
- shifts the sleep delay to after the ss_playlist is saved to allow time for cloudinary to update the photo, before attaching to spotify playlist cover image.

Fixes # (issue)
[https://trello.com/c/EFCwpgW2](https://trello.com/c/EFCwpgW2)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] New Playlist
![image](https://user-images.githubusercontent.com/81938708/228446257-e1b31e85-a3ed-4c7a-a5a5-abc643141837.png)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
