### PR TITLE
Apply d-none to carousel container if playlist empty

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -3,7 +3,7 @@
   <div class="container container-scroll" data-controller="time-zone">
     <h2 class="hide greeting" data-homepage-target="hide">Good <span data-time-zone-target="dayPeriod"></span>, <br><em><%= current_user.nickname %></em></h2>
   </div>
-  <div class="container carousel-container">
+  <div class="container carousel-container <%= "d-none" if current_user.user_playlists.empty? %>">
     <h2 class="hide carousel-greeting text-center" data-homepage-target="hide">Here is what you have been listening to</h2>
     <!-- Carousel -->
     <div class="carousel hide" data-controller="flickity" data-homepage-target="hide">


### PR DESCRIPTION
# Description
- hides the home carousel if user playlist is empty

Fixes # (issue)
[https://trello.com/c/8YQn3ExD](https://trello.com/c/8YQn3ExD)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] Homepage with empty playlist
![image](https://user-images.githubusercontent.com/81938708/228448932-77a19651-97f1-4b9a-ad6f-e5c37ec6c20d.png)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
