### PR TITLE
Adds logic to only remove thumbnail for gallery and not vault

### DIFF
--- a/app/javascript/controllers/share_button_controller.js
+++ b/app/javascript/controllers/share_button_controller.js
@@ -30,7 +30,9 @@ export default class extends Controller {
         } else {
           this.shareTarget.outerHTML = lock;
         }
-        this.thumbnailTarget.remove();
+        if (window.location.href.includes("playlist")) {
+          this.thumbnailTarget.remove();
+        }
       });
   }
 }


### PR DESCRIPTION
# Description

When user decides to hide a playlist from their vault, the playlist thumbnail will no longer we removed at the background.

Fixes # (issue)
https://trello.com/c/KxmUY4fQ

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
