### PR TITLE
Removes capitalization from user's nickname

### DIFF
--- a/app/views/playlists/index.html.erb
+++ b/app/views/playlists/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="profile-header">
     <%= render 'shared/user_avatar_small', user: @user %>
-    <h1 class="text-center"><%= @user.nickname.capitalize %>'s Gallery</h2>
+    <h1 class="text-center"><%= @user.nickname %>'s Gallery</h2>
   </div>
   <% if @playlists.where(is_shared: true).empty?  %>
     <%= render "shared/default_gallery" %>


### PR DESCRIPTION
# Description
- removes capitalization on the user's nickname in gallery

Fixes # (issue)
[https://trello.com/c/Hrc6wiIw](https://trello.com/c/Hrc6wiIw)

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Gallery
![image](https://user-images.githubusercontent.com/81938708/228492994-c40c3a8d-c15b-49f0-8294-2f0f2a721c80.png)

# Checklist:
- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
