### PR TITLE
Regenerate image button and page

### DIFF
--- a/app/assets/stylesheets/components/_webplayer.scss
+++ b/app/assets/stylesheets/components/_webplayer.scss
@@ -38,6 +38,11 @@ ul#episodes::-webkit-scrollbar, .list-items-container::-webkit-scrollbar {
   color: $cold-color;
 }
 
+#generate-button p{
+  color: $cold-color;
+  cursor: pointer;
+}
+
 .create-btn {
   color: #fff;
   width: 20%;

--- a/app/assets/stylesheets/pages/_image_display.scss
+++ b/app/assets/stylesheets/pages/_image_display.scss
@@ -1,0 +1,3 @@
+.regenerate-image-container {
+  min-height: 300px;
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -4,3 +4,4 @@
 @import "vault";
 @import "home";
 @import "body";
+@import "image_display";

--- a/app/views/playlists/_image_display.html.erb
+++ b/app/views/playlists/_image_display.html.erb
@@ -1,8 +1,8 @@
 <div>
-  <div data-image-creation-target='image' class='text-center d-none'>
+  <div data-image-creation-target='image' class='text-center d-none regenerate-image-container'>
     <img src="" alt="">
   </div>
-  <div style='cursor: pointer' class='d-flex d-none justify-content-center py-4' data-image-creation-target='regenerateButton'>
+  <div style='cursor: pointer' class='d-flex d-none justify-content-center' data-image-creation-target='regenerateButton'>
     <i class='fa-solid fa-arrows-rotate' data-action='click->image-creation#generateImage'></i>
   </div>
 </div>

--- a/app/views/playlists/new.html.erb
+++ b/app/views/playlists/new.html.erb
@@ -2,10 +2,10 @@
 <div class="container" id="new-playlist" data-controller='image-creation' data-image-creation-eventid-value="<%= @event.id %>">
   <h1 class="mb-3">New Playlist Preview</h1>
   <div id="first-song" value="<%= @song_uris.first %>"></div>
-  <p><i class="fa-solid fa-chevron-left"></i> <%= link_to 'Edit filters', edit_event_path(@event)%></p>
-  <%# Generate image button %>
-  <div class="mb-5">
-    <div class='btn create-btn' data-action='click->image-creation#showImage' data-image-creation-target='generateImageButton'>Generate Image</div>
+  <div class="d-flex justify-content-between align-items-start mb-5">
+    <p><i class="fa-solid fa-chevron-left"></i> <%= link_to 'Edit filters', edit_event_path(@event)%></p>
+    <%# Generate image button %>
+    <div id="generate-button" data-action='click->image-creation#showImage' data-image-creation-target='generateImageButton'><p> Generate Image <i class="fa-solid fa-chevron-right"></i></p></div>
   </div>
   <% if @songs.count == 0 %>
     <h2 class="mt-5">Oopsie Daisy! Your library does not contain songs which match your filters.</h2>


### PR DESCRIPTION
# Description

Made small styling changes to generate image button on playlist new and resized container on image display page so that buttons dont shift when image is generated

Fixes # (issue)
https://trello.com/c/IKVvFHk6

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

<img width="669" alt="Screenshot 2023-03-29 at 9 59 42 PM" src="https://user-images.githubusercontent.com/123570606/228562376-764d0f29-eb30-4780-8cae-f6cbcbd31212.png">


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
