### PR TITLE
changed carousell colour for homeoapge

### DIFF
--- a/app/assets/stylesheets/pages/_body.scss
+++ b/app/assets/stylesheets/pages/_body.scss
@@ -75,6 +75,10 @@
     // text-shadow: 0 0 15px $white, 0 0 15px $white;
   }
 
+  .playlist-card>h1 {
+    color: $white;
+  }
+
   @media(max-width: 401px) {
     .y.scroll-snapping {
       background-position: top 10rem left 25%;


### PR DESCRIPTION
# Description

<img width="472" alt="Screenshot 2023-03-30 at 10 34 38 AM" src="https://user-images.githubusercontent.com/123570606/228713373-e96f8932-ffa8-4e4a-9247-200102a696c3.png">

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


