### PR TITLE
delete event from vault by swiping up

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  protect_from_forgery prepend: true
 
   # resource is the User instance created from users#spotify
   def after_sign_in_path_for(resource)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -64,6 +64,12 @@ class EventsController < ApplicationController
     end
   end
 
+  # DELETE /events/:id
+  def destroy
+    @event = Event.find(params[:id])
+    @event.destroy
+  end
+
   private
 
   def event_params

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -52,5 +52,8 @@ application.register("share-button-creation", ShareButtonCreationController)
 import SliderController from "./slider_controller"
 application.register("slider", SliderController)
 
+import SwipeEventController from "./swipe_event_controller"
+application.register("swipe-event", SwipeEventController)
+
 import TimeZoneController from "./time_zone_controller"
 application.register("time-zone", TimeZoneController)

--- a/app/javascript/controllers/swipe_event_controller.js
+++ b/app/javascript/controllers/swipe_event_controller.js
@@ -19,14 +19,13 @@ export default class extends Controller {
     const distance = this.startY - endY;
     const eventElement = event.target.closest(".vault-event");
 
+    // checks distance between touch start and end points, detects a swipe if more than 50 px
     if (distance > 50) {
-      console.log("user swiped up");
       this.deleteEvent(this.eventidValue, eventElement);
     }
   }
 
   async deleteEvent(eventId, eventElement) {
-    console.log(eventId);
     const url = `/events/${eventId}`;
     await fetch(url, {
       method: "DELETE",

--- a/app/javascript/controllers/swipe_event_controller.js
+++ b/app/javascript/controllers/swipe_event_controller.js
@@ -6,9 +6,7 @@ export default class extends Controller {
     eventid: String,
   };
 
-  connect() {
-    console.log("hello from swipe controller");
-  }
+  connect() {}
 
   start(event) {
     this.startY = event.touches[0].clientY;

--- a/app/javascript/controllers/swipe_event_controller.js
+++ b/app/javascript/controllers/swipe_event_controller.js
@@ -1,0 +1,37 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="swipe-event"
+export default class extends Controller {
+  static values = {
+    eventid: String,
+  };
+
+  connect() {
+    console.log("hello from swipe controller");
+  }
+
+  start(event) {
+    this.startY = event.touches[0].clientY;
+  }
+
+  end(event) {
+    const endY = event.changedTouches[0].clientY;
+    const distance = this.startY - endY;
+    const eventElement = event.target.closest(".vault-event");
+
+    if (distance > 50) {
+      console.log("user swiped up");
+      this.deleteEvent(this.eventidValue, eventElement);
+    }
+  }
+
+  async deleteEvent(eventId, eventElement) {
+    console.log(eventId);
+    const url = `/events/${eventId}`;
+    await fetch(url, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+    });
+    eventElement.remove();
+  }
+}

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="vault-top">
     <h1 class="text-center">My Vault</h2>
     <div class="default-events" id="#vault-events-container">
-      <ul id="vault-events"  class="list-unstyled d-flex justify-content-start gap-3">
+      <ul id="vault-events" class="list-unstyled d-flex justify-content-start gap-3">
         <% @events.each do |event| %>
           <div data-controller='swipe-event' data-swipe-event-eventid-value="<%= event.id %>">
             <li data-action='touchstart->swipe-event#start touchend->swipe-event#end'><%= link_to event.title, edit_event_path(event), class: "btn default vault-event" %></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,9 +2,11 @@
   <div class="vault-top">
     <h1 class="text-center">My Vault</h2>
     <div class="default-events" id="#vault-events-container">
-      <ul id="vault-events" class="list-unstyled d-flex justify-content-start gap-3">
+      <ul id="vault-events"  class="list-unstyled d-flex justify-content-start gap-3">
         <% @events.each do |event| %>
-          <li><%= link_to event.title, edit_event_path(event), class: "btn default vault-event" %></li>
+          <div data-controller='swipe-event' data-swipe-event-eventid-value="<%= event.id %>">
+            <li data-action='touchstart->swipe-event#start touchend->swipe-event#end'><%= link_to event.title, edit_event_path(event), class: "btn default vault-event" %></li>
+          </div>
         <% end %>
       </ul>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     resources :playlists, only: %i[index]
   end
 
-  resources :events, only: %i[index new create edit update] do
+  resources :events, only: %i[index new create edit update destroy] do
     get :image
     resources :playlists, only: %i[new create]
   end


### PR DESCRIPTION
# Description

Good evening friends. I couldn't help myself. Ajax.
I have too many events in my vault with nonsensical names. i need to delete them. 
so now you can delete by swiping up from your vault.
(I realise it leaves a small hole in the carousel where it used to be until you refresh. this will be a fix for another day)
Happy deleting!


Fixes # (issue)
The issue of gibberish events

## Type of change
- [ ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
can you see this video?
https://user-images.githubusercontent.com/99415923/228893608-ae6011cd-5b86-40f1-b59f-f9102ed4593c.MOV



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
