### PR TITLE
Adds an active record filter to only show shared playlist in homepage

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,7 @@ class User < ApplicationRecord
       account.update!(spotify_auth:)
     else
       account = User.create!(email: spotify_user.email, password: Devise.friendly_token[0, 20], nickname: spotify_user.display_name, spotify_auth:)
-      
+
       if !spotify_user.images.empty?
         require "open-uri"
         avatar = URI.open(spotify_user.images.first.url)
@@ -40,7 +40,7 @@ class User < ApplicationRecord
     end
     account
   end
-  
+
   def spotify_user
     RSpotify::User.new(spotify_auth)
   end
@@ -50,7 +50,7 @@ class User < ApplicationRecord
   end
 
   def others_playlists
-    Playlist.where.not(user: self).order(created_at: :DESC)
+    Playlist.where(is_shared: true).where.not(user: self).order(created_at: :DESC)
   end
 
   # Add 3 default events to new users
@@ -70,7 +70,7 @@ class User < ApplicationRecord
       time: 0,
       user: self
     )
-  
+
     Event.create!(
       title: 'Acoustic',
       min_acousticness: 0.8,
@@ -86,7 +86,7 @@ class User < ApplicationRecord
       time: 1,
       user: self
     )
-  
+
     Event.create!(
       title: 'Sleep',
       min_acousticness: 0.0,


### PR DESCRIPTION
# Description

Adds a big fix to only show shared playlists in the gallery homepage.

Fixes # (issue)
https://trello.com/c/ddI8Pzv6

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
