### PR TITLE
Load spotify iframe when flipped

### DIFF
--- a/app/javascript/controllers/gallery_card_controller.js
+++ b/app/javascript/controllers/gallery_card_controller.js
@@ -2,12 +2,15 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="gallery-card"
 export default class extends Controller {
-  static targets = ["card"]
+  static targets = ["card", "iframeCard"]
 
   click (e) {
     const all_cards = document.querySelectorAll('[data-gallery-card-target="card"]')
     all_cards.forEach((c)=>c.classList.remove("is-flipped"))
+    const iframeCards = document.querySelectorAll('[data-gallery-card-target="iframeCard"]')
+    iframeCards.forEach((iframe)=>iframe.classList.add("d-none"))
 
     this.cardTarget.classList.add("is-flipped")
+    this.iframeCardTarget.classList.remove("d-none")
   }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,11 +46,11 @@ class User < ApplicationRecord
   end
 
   def user_playlists
-    Playlist.where(user: self).order(created_at: :DESC)
+    Playlist.where(user: self).order(created_at: :desc)
   end
 
   def others_playlists
-    Playlist.where(is_shared: true).where.not(user: self).order(created_at: :DESC)
+    Playlist.where(is_shared: true).where.not(user: self).order(updated_at: :desc)
   end
 
   # Add 3 default events to new users

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -23,7 +23,7 @@
       <h2 class="hide mb-3" data-homepage-target="hide">Discover Playlists</h2>
     </div>
     <div class="hide" data-homepage-target="hide">
-      <% current_user.others_playlists.sample(10).each do |playlist| %>
+      <% current_user.others_playlists.each do |playlist| %>
         <%= render "shared/gallery_card", playlist: playlist %>
       <% end %>
     </div>

--- a/app/views/shared/_gallery_card.html.erb
+++ b/app/views/shared/_gallery_card.html.erb
@@ -11,7 +11,7 @@
           <%= link_to "", user_playlists_path(playlist.user) %>
         </div>
       </div>
-      <div class="card__face card__face--back">
+      <div class="card__face card__face--back d-none" data-gallery-card-target="iframeCard">
         <iframe style="border-radius:12px;" src="https://open.spotify.com/embed/playlist/<%= playlist.spotify_id %>?utm_source=generator&theme=0" width="100%" height="100%" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
       </div>
     </div>

--- a/app/views/shared/_gallery_card.html.erb
+++ b/app/views/shared/_gallery_card.html.erb
@@ -3,7 +3,7 @@
     <div class="card" data-gallery-card-target="card">
       <div class="card__face card__face--front">
         <div class="gallery-photo" data-action="click->gallery-card#click">
-          <%= cl_image_tag playlist.photo.key, crop: :fill %>
+          <%= cl_image_tag playlist.photo.key, crop: :fill, loading: "lazy" %>
         </div>
         <div class="gallery-user d-flex align-items-center gap-3 mt-2">
           <%= render 'shared/user_avatar_small', user: playlist.user %>


### PR DESCRIPTION
# Description
- display none is applied to all the back card by default
- only remove the display none class when the card is flipped
- images in the gallery is set to lazy loading
- the latest shared playlist is shown first
- all shared playlist is shown

Fixes # (issue)
[https://trello.com/c/QGuPYRpE](https://trello.com/c/QGuPYRpE)

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
- [x] Homepage when first loaded(no long list of spotify errors
![image](https://user-images.githubusercontent.com/81938708/229272941-27f66609-00b8-4ef3-b053-c588eae8d5d4.png)

- [x] When card is flipped
![image](https://user-images.githubusercontent.com/81938708/229273021-e4c8ccc5-bddb-4594-88cb-e42f78d9de3a.png)


# Checklist:
- [x] I have performed a self-review of my code
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
