### PR TITLE
removes user-library-modify scope and sets iframe limit again

### DIFF
--- a/app/javascript/controllers/homepage_controller.js
+++ b/app/javascript/controllers/homepage_controller.js
@@ -1,18 +1,17 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="homepage"
 export default class extends Controller {
-  static targets = ['hide']
+  static targets = ["hide"];
   connect() {
-
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
-          entry.target.classList.add('active');
+          entry.target.classList.add("active");
         } else {
-          entry.target.classList.remove('active');
+          entry.target.classList.remove("active");
         }
-      })
+      });
     });
 
     this.hideTargets.forEach((el) => observer.observe(el));

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -23,7 +23,7 @@
       <h2 class="hide mb-3" data-homepage-target="hide">Discover Playlists</h2>
     </div>
     <div class="hide" data-homepage-target="hide">
-      <% current_user.others_playlists.each do |playlist| %>
+      <% current_user.others_playlists.sample(10).each do |playlist| %>
         <%= render "shared/gallery_card", playlist: playlist %>
       <% end %>
     </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,7 +1,7 @@
 require 'rspotify/oauth'
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :spotify, ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_SECRET"], scope: 'user-read-email user-read-private user-library-read user-library-modify playlist-modify-public playlist-modify-private streaming ugc-image-upload'
+  provider :spotify, ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_SECRET"], scope: 'user-read-email user-read-private user-library-read playlist-modify-public playlist-modify-private streaming ugc-image-upload'
 end
 
 OmniAuth.config.allowed_request_methods = [:post, :get]


### PR DESCRIPTION
# Description

Restores 10 iframe limit on home page to prevent safari downloads, until we find another fix
I've also removed one of the scopes we currently aren't using

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Screenshot A
- [x] Screenshot B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
