### PR TITLE
Edits ways of linking to spotify on flipped card

### DIFF
--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -67,7 +67,6 @@
    width: 500px;
   }
   .secret-box {
-    width: 160px;
-    height: 160px;
+    display:none;
   }
 }

--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -31,7 +31,7 @@
     min-height: 115px;
     background: transparent;
     position: absolute;
-    top: 55px;
+    top: 110px;
     left: 15px;
     z-index: 100;
   }

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -39,7 +39,6 @@ export default class extends Controller {
   }
 
   closeImage(event) {
-    console.log("click registered");
     if (event.target !== this.secretBoxTarget) {
       this.imagePreviewTarget.innerHTML = "";
       this.iframeTarget.classList.remove("darken");

--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
     "imagePreview",
     "iframe",
     "secretBox",
+    "enlargedImage",
   ];
   static values = {
     image: String,
@@ -33,13 +34,16 @@ export default class extends Controller {
   }
 
   showBigImage() {
-    this.imagePreviewTarget.innerHTML = `<img src="${this.imageValue}">`;
+    this.imagePreviewTarget.innerHTML = `<img src="${this.imageValue}" data-profile-modal-target="enlargedImage">`;
     this.iframeTarget.classList.add("darken");
     this.iframeTarget.classList.add("pe-none");
   }
 
   closeImage(event) {
-    if (event.target !== this.secretBoxTarget) {
+    if (
+      event.target !== this.secretBoxTarget &&
+      event.target !== this.enlargedImageTarget
+    ) {
       this.imagePreviewTarget.innerHTML = "";
       this.iframeTarget.classList.remove("darken");
       this.iframeTarget.classList.remove("pe-none");

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -50,7 +50,9 @@
             <iframe data-profile-modal-target='iframe' id="playlist-show" style="border-radius:12px" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="600" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
           </div>
           <div class='secret-box' data-action='click->profile-modal#showBigImage' data-profile-modal-target='secretBox'></div>
-          <div class="image-preview" data-profile-modal-target='imagePreview' data-profile-modal-target="imagePreview"></div>
+          <a href="<%= "https://open.spotify.com/playlist/#{playlist.spotify_id}" %>" target="_blank">
+            <div class="image-preview" data-profile-modal-target='imagePreview' data-profile-modal-target="imagePreview"></div>
+          </a>
         </div>
       </section>
     </div>

--- a/app/views/shared/_profile.html.erb
+++ b/app/views/shared/_profile.html.erb
@@ -34,7 +34,6 @@
                 <span style="padding-left: 10px;">Share to Gallery</span>
               </div>
             <% end %>
-            <a href="<%= "https://open.spotify.com/playlist/#{playlist.spotify_id}" %>" target="_blank">Listen on <%= image_tag "spotify_logo.png", class: 'logo' %></a>
             <div class='d-flex align-items-center gap-2'>
               <div class=<%= playlist.user_id == current_user.id ? "" : "d-none" %>>
                 <%= link_to playlist_path(playlist), class:'p-2 text-decoration-none', data: {action: "click->profile-modal#close", turbo_method: :delete, turbo_confirm: "Are you sure?"} do %>
@@ -46,8 +45,10 @@
               </div>
             </div>
           </div>
+          <div class="text-center mb-2"><a href="<%= "https://open.spotify.com/playlist/#{playlist.spotify_id}" %>" target="_blank">Listen on <%= image_tag "spotify_logo.png", class: 'logo' %></a></div>
           <div class="iframe-wrapper d-flex justify-content-center"  data-action='click->profile-modal#closeImage'>
-            <iframe data-profile-modal-target='iframe' id="playlist-show" style="border-radius:12px" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="600" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>
+            <iframe data-profile-modal-target='iframe' id="playlist-show" style="border-radius:12px" src=<%= "https://open.spotify.com/embed/playlist/#{playlist.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="600" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+          </div>
           <div class='secret-box' data-action='click->profile-modal#showBigImage' data-profile-modal-target='secretBox'></div>
           <div class="image-preview" data-profile-modal-target='imagePreview' data-profile-modal-target="imagePreview"></div>
         </div>


### PR DESCRIPTION
# Description
1. Improves the layout of the spotify link on flipped card. was too squished on mobile
2. Image enlargement feature only on mobile
3. When user clicks enlarged image, it now links to spotify


Fixes https://trello.com/c/RIGuEN2K

- [x] New feature

# How Has This Been Tested?

- [x] before
<img width="359" alt="Screenshot 2023-04-12 at 10 48 26 AM" src="https://user-images.githubusercontent.com/99415923/231335411-21dc8aaa-11de-4bd0-8463-41d3922d5bb4.png">

- [x] after
<img width="354" alt="Screenshot 2023-04-12 at 10 48 39 AM" src="https://user-images.githubusercontent.com/99415923/231335432-4ecfa1b9-69bc-48e8-a8d7-97e440c6e6e8.png">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
