### PR TITLE
Use @user to display nickname

### DIFF
--- a/app/views/shared/_default_gallery.html.erb
+++ b/app/views/shared/_default_gallery.html.erb
@@ -13,7 +13,7 @@
 
   <div class="container">
   <div class="d-flex flex-column" style="margin-top: 50px; !important">
-    <p class="text-center"><%= @playlists.first.user.nickname %> has no shared playlists</p>
+    <p class="text-center"><%= @user.nickname %> has no shared playlists</p>
   </div>
 
 <% end %>


### PR DESCRIPTION
# Description
- NoMethodError when try to access user's gallery, in which the user does not have any playlist (shared and private)

Fixes # (issue)
- use @user to get the nickname, instead of @playlists.first.user, as @playlists could be empty.
[https://trello.com/c/dpyrt72M](https://trello.com/c/dpyrt72M)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Alice's Gallery, with no playlists
![image](https://user-images.githubusercontent.com/81938708/231980563-fe0c7af3-6fe6-4af3-b1c1-59dcac56e59c.png)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
