### PR TITLE
Limit the songs import to 2000

### DIFF
--- a/app/services/import_songs_service.rb
+++ b/app/services/import_songs_service.rb
@@ -3,12 +3,12 @@ class ImportSongsService
     @tracks = spotify_user.saved_tracks(offset: 0, limit: 50)
     all_tracks = @tracks
     offset = 50
-    while @tracks.count == 50
+    while (@tracks.count == 50 && offset <= 2000 )
       @tracks = spotify_user.saved_tracks(offset:, limit: 50)
       all_tracks.concat(@tracks)
       offset += 50
     end
-
+    
     insert_songs(all_tracks, current_user)
 
     # get the spotify song URIs from the filtered_array and create a playlist with these +/- store in user's spotify


### PR DESCRIPTION
# Description
- users encounter error when user's like songs library is greater than 4000.

Fixes # (issue)
- limit the song import to 2000 songs
[https://trello.com/c/lfqLdpZF](https://trello.com/c/lfqLdpZF)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Raise to check that offset limit works
![image](https://user-images.githubusercontent.com/81938708/232007648-df2db3ed-e5bb-4e14-80ba-9cca36e37e06.png)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
