### PR TITLE
Sync playlist creation preview with created playlist

### DIFF
--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -30,7 +30,7 @@ class PlaylistsController < ApplicationController
 
     @ss_playlist, spotify_playlist = ::MakeSpotifyPlaylistService.call(
       current_user:,
-      event: @event,
+      song_uris: song_uris_params,
       playlist_params:,
       image_url: image_params[:photo]
     )
@@ -83,6 +83,10 @@ class PlaylistsController < ApplicationController
 
   def image_params
     params.require(:playlist).permit(:photo)
+  end
+
+  def song_uris_params
+    params.require(:playlist).permit(:song_uris)["song_uris"].split(',')
   end
 
   def update_spotify_playlist_image(ss_playlist, spotify_playlist)

--- a/app/services/make_spotify_playlist_service.rb
+++ b/app/services/make_spotify_playlist_service.rb
@@ -1,8 +1,7 @@
 class MakeSpotifyPlaylistService
-  def self.call(event:, current_user:, playlist_params:, image_url:)
+  def self.call(song_uris:, current_user:, playlist_params:, image_url:)
     playlist_image = URI.open(image_url)
-    # @event, current_user, @ss_playlist
-    songs, song_uris = event.filter_songs(current_user)
+    # song_uris, current_user, @ss_playlist
     # make empty playlist in spotify playlist
     spotify_user = current_user.spotify_user
     spotify_playlist = spotify_user.create_playlist!(playlist_params[:title])

--- a/app/views/playlists/_playlist_creation_form.html.erb
+++ b/app/views/playlists/_playlist_creation_form.html.erb
@@ -2,6 +2,7 @@
   <%= simple_form_for [@event, @playlist], defaults: { required: false } do |f| %>
     <%= f.input :photo, as: :hidden, value: "", input_html: { data: {image_creation_target: "photo"} } %>
     <%= f.input :title, as: :hidden, input_html: { value: @event.title || 'My Playlist', class: "new-playlist-form", readonly: true, data: {image_creation_target: "title"} } %>
+    <%= f.input :song_uris, as: :hidden, input_html: { value: @song_uris.join(',') } %>
     <%= f.button :submit,"Create Playlist", class: "btn create-btn", data: {bs_toggle: "modal", bs_target: "#playlistSpinnerModal"} %>
   <% end %>
 </div>


### PR DESCRIPTION
# Description
- When creating a new playlist, the playlist preview and the final create playlist is different.

Fixes # (issue)
- add an additional hidden input to the playlist creation form for the song_uris.
[https://trello.com/c/Tf9ct30y](https://trello.com/c/Tf9ct30y)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Playlist Preview
![image](https://user-images.githubusercontent.com/81938708/232039297-2b6d0cf9-ffad-4df0-ad87-c67838f547ca.png)

- [x] Final Playlist
![image](https://user-images.githubusercontent.com/81938708/232039483-d8e73b17-4c36-49ef-91ce-585cd3bac8a0.png)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
