### PR TITLE
concurrency back to 3 and downgrades sidekiq version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
 gem "bootsnap", require: false
 
 # Sidekiq for background jobs
-gem "sidekiq"
+gem 'sidekiq', '~> 6.5'
 gem "sidekiq-failures", "~> 1.0"
 
 # Use Sass to process CSS

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,4 +1,4 @@
-:concurrency: 1
+:concurrency: 3
 :timeout: 60
 :verbose: true
 :queues:


### PR DESCRIPTION
# Description

HELLO and RESP3 are not supported on RedisCloud. Downgrades sidekiq version to 6.5


Fixes # (issue)
https://trello.com/c/UCnV4e4y

## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
