### PR TITLE
Sync Users Liked Songs

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,14 +12,24 @@ class PagesController < ApplicationController
 
   def load_songs
     # get all the songs from user's library and their properties, and load into songs table
-    ::ImportSongsService.call(
-      spotify_user: current_user.spotify_user,
-      current_user: current_user
-    )
+    if new_user?
+      ::ImportSongsService.call(
+        spotify_user: current_user.spotify_user,
+        current_user: current_user
+      )
+    else
+    end
 
     # Sync user's playlists with Spotify as a background job.
     UpdatePlaylistsJob.perform_later(current_user)
 
     redirect_to root_path
+  end
+
+  private
+
+  def new_user?
+    # User created within the last 60 seconds
+    (Time.now - current_user.created_at) < 60
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,7 +12,7 @@ class PagesController < ApplicationController
 
   def load_songs
     # get all the songs from user's library and their properties, and load into songs table
-    if new_user?
+    if current_user.new_user?
       ::ImportSongsService.call(
         spotify_user: current_user.spotify_user,
         current_user: current_user
@@ -24,12 +24,5 @@ class PagesController < ApplicationController
     UpdatePlaylistsJob.perform_later(current_user)
 
     redirect_to root_path
-  end
-
-  private
-
-  def new_user?
-    # User created within the last 60 seconds
-    (Time.now - current_user.created_at) < 60
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,6 +18,9 @@ class PagesController < ApplicationController
         current_user: current_user
       )
     else
+      ::ImportAllSongsJob.perform_later(
+        current_user: current_user
+      )
     end
 
     # Sync user's playlists with Spotify as a background job.

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -18,13 +18,9 @@ class PagesController < ApplicationController
         current_user: current_user
       )
     else
-      ::ImportAllSongsJob.perform_later(
-        current_user: current_user
-      )
+      ::ImportAllSongsJob.perform_later(current_user:)
+      ::UpdatePlaylistsJob.perform_later(current_user:)
     end
-
-    # Sync user's playlists with Spotify as a background job.
-    UpdatePlaylistsJob.perform_later(current_user)
 
     redirect_to root_path
   end

--- a/app/jobs/import_all_songs_job.rb
+++ b/app/jobs/import_all_songs_job.rb
@@ -1,0 +1,14 @@
+class ImportAllSongsJob < ApplicationJob
+  queue_as :default
+
+  def perform(current_user:)
+    spotify_user = current_user.spotify_user
+    offset = 0
+    loop do
+      tracks = ::ImportSongsByBatchService.call(spotify_user:, current_user:, offset:)
+      offset += tracks.count
+
+      break if (tracks.count < 50)
+    end
+  end
+end

--- a/app/jobs/import_all_songs_job.rb
+++ b/app/jobs/import_all_songs_job.rb
@@ -10,5 +10,7 @@ class ImportAllSongsJob < ApplicationJob
 
       break if (tracks.count < 50)
     end
+
+    ::UpdateLikedSongsJob.perform_later(current_user:)
   end
 end

--- a/app/jobs/update_liked_songs_job.rb
+++ b/app/jobs/update_liked_songs_job.rb
@@ -1,0 +1,9 @@
+class UpdateLikedSongsJob < ApplicationJob
+  queue_as :default
+
+  def perform(current_user:)
+    # Remove the songs_user if it is not updated within the last 60 minutes
+    cutoff_time = Time.now - 3600
+    current_user.songs_users.destroy_by("updated_at < ?", cutoff_time)
+  end
+end

--- a/app/jobs/update_playlists_job.rb
+++ b/app/jobs/update_playlists_job.rb
@@ -1,8 +1,8 @@
 class UpdatePlaylistsJob < ApplicationJob
   queue_as :default
 
-  def perform(user)
-    user.playlists.each do |playlist|
+  def perform(current_user:)
+    current_user.playlists.each do |playlist|
       playlist.destroy unless RSpotify::Playlist.find_by_id(playlist.spotify_id).public
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,13 @@ class User < ApplicationRecord
     Playlist.where(is_shared: true).where.not(user: self).order(updated_at: :desc)
   end
 
+  def new_user?
+    # User created within the last 60 seconds
+    (Time.now - created_at) <= 60
+  end
+
+  private
+
   # Add 3 default events to new users
   def add_default_events
     Event.create!(

--- a/app/services/import_songs_by_batch_service.rb
+++ b/app/services/import_songs_by_batch_service.rb
@@ -1,0 +1,53 @@
+class ImportSongsByBatchService
+  def self.call(spotify_user:, current_user:, offset:)
+    new(spotify_user:, current_user:, offset:).call
+  end
+
+  def initialize(spotify_user:, current_user:, offset:)
+    @spotify_user = spotify_user
+    @current_user = current_user
+    @offset = offset
+  end
+
+  def call
+    import_songs
+
+    return @tracks
+  end
+
+  private
+
+  attr_reader :spotify_user, :current_user, :offset
+
+  def fetch_tracks
+    @tracks = spotify_user.saved_tracks(offset:, limit: 50)
+  end
+
+  def import_songs
+    fetch_tracks.each do |track|
+      # for each track, check if it's already in the DB, if not create the song
+      song = Song.find_by(spotify_id: track.id) 
+      song = create_song(track) if song.nil? 
+
+      # check if song-user combo exists, if not insert that into the join table
+      # update the updated_at, so we can use it to remove songsUser that are not updated (not in user's liked songs)
+      SongsUser.find_or_create_by(song: song, user: current_user).touch
+    end
+  end
+
+  def create_song(track)
+    features = RSpotify::AudioFeatures.find(track.id)
+
+    Song.create do |song|
+      song.acousticness = features.acousticness
+      song.danceability = features.danceability
+      song.energy = features.energy
+      song.tempo = features.tempo
+      song.valence = features.valence
+      song.spotify_id = track.id
+      song.name = track.name
+      song.uri = track.uri
+      song.artist = track.artists.first.name
+    end
+  end
+end

--- a/test/jobs/import_all_songs_job_test.rb
+++ b/test/jobs/import_all_songs_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ImportAllSongsJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/update_liked_songs_job_test.rb
+++ b/test/jobs/update_liked_songs_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UpdateLikedSongsJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# Description
- Add a new service to import the song by batch, taking an additional argument, offset, for a more robust and reusable service.
- Add a new background job to import the songs for user login, but not for user sign up.
- When importing songs, use the "touch" method to update the "updated_at" variable of the songs_users which are still in the user's Liked Songs.
- Add a new background job to update the user's liked songs by destroying the songs_user which are not updated within the last one hour. The one hour cutoff time is just a rough estimation on the safe time from the last song import.
- The update liked songs job is only queued after all the songs are imported. This is just in case we have many workers, and other workers are updating the songs before all the songs are imported. So this would prevent us from accidentally removing user's liked songs from SoundState. 

Note: will update the new user song import once the refactoring pull request is merged.

Fixes # (issue)
[https://trello.com/c/x0r82z9u](https://trello.com/c/x0r82z9u)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
songs table not affect, while the songs_user join table is updated.

- [x] Before Login
![image](https://user-images.githubusercontent.com/81938708/233768080-34c04d37-c132-4b7d-8b39-487d2ce76946.png)

- [x] After Login
![image](https://user-images.githubusercontent.com/81938708/233768135-dfbab300-b694-4e7c-8979-98b20202058d.png)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
