### PR TITLE
Freeze scroll when modal is open

### DIFF
--- a/app/javascript/controllers/profile_modal_controller.js
+++ b/app/javascript/controllers/profile_modal_controller.js
@@ -18,15 +18,14 @@ export default class extends Controller {
 
   connect() {}
   open() {
+    document.body.style.overflow = "hidden";
     setTimeout((event) => {
       this.modalTarget.classList.remove("hidden");
     }, 500);
   }
 
   close() {
-    // setTimeout(() => {
-    //   this.modalTarget.classList.add("hidden");
-    // }, 500);
+    document.body.style.overflow = "unset";
 
     this.modalTarget.classList.add("hidden");
     this.cardTargets.forEach((c) => c.classList.remove("is-flipped"));


### PR DESCRIPTION
# Description
- freeze scroll of the page when modal is up for the vault and gallery page.
- user can still scroll the playlist in the iframe.

Fixes # (issue)
[https://trello.com/c/1Qr2Rr5x](https://trello.com/c/1Qr2Rr5x)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [ ] Screenshot A
![image](https://user-images.githubusercontent.com/81938708/233907563-5c3121d9-41af-4499-b83e-4b5ba0e69394.png)

# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
