### PR TITLE
Import 200 songs new user then background job for the rest

### DIFF
--- a/app/jobs/import_all_songs_job.rb
+++ b/app/jobs/import_all_songs_job.rb
@@ -1,9 +1,9 @@
 class ImportAllSongsJob < ApplicationJob
   queue_as :default
 
-  def perform(current_user:)
+  def perform(current_user:, offset:)
     spotify_user = current_user.spotify_user
-    offset = 0
+    offset ||= 0
     loop do
       tracks = ::ImportSongsByBatchService.call(spotify_user:, current_user:, offset:)
       offset += tracks.count

--- a/app/services/import_songs_service.rb
+++ b/app/services/import_songs_service.rb
@@ -16,46 +16,17 @@ class ImportSongsService
 
   attr_reader :spotify_user, :current_user
 
-  def fetch_all_tracks
-    all_tracks = []
-    offset = 0
-
-    loop do
-      tracks = spotify_user.saved_tracks(offset:, limit: 50)
-      all_tracks.concat(tracks)
-      offset += 50
-      
-      # Limit import songs to 400, to limit api request.
-      break unless (tracks.count == 50 && offset < 400)
-    end
-
-    return all_tracks
-  end
-
   def import_songs
-    fetch_all_tracks.each do |track|
-      # for each track, check if it's already in the DB, if not create the song
-      song = Song.find_by(spotify_id: track.id) 
-      song = create_song(track) if song.nil? 
+    offset = 0
+    loop do
+      tracks = ::ImportSongsByBatchService.call(spotify_user:, current_user:, offset:)
+      offset += tracks.count
 
-      # check if song-user combo exists, if not insert that into the join table
-      SongsUser.find_or_create_by(song: song, user: current_user)
+      break if (tracks.count < 50 || offset >= 200)
     end
-  end
 
-  def create_song(track)
-    features = RSpotify::AudioFeatures.find(track.id)
-
-    Song.create do |song|
-      song.acousticness = features.acousticness
-      song.danceability = features.danceability
-      song.energy = features.energy
-      song.tempo = features.tempo
-      song.valence = features.valence
-      song.spotify_id = track.id
-      song.name = track.name
-      song.uri = track.uri
-      song.artist = track.artists.first.name
+    if offset >= 200
+      ::ImportAllSongsJob.perform_later(current_user:, offset:) 
     end
   end
 end


### PR DESCRIPTION
# Description
- For new user, import the first 200 songs. 200 songs is so that there are enough songs that do not take too long to import.
- The rest of the songs are imported using background job

Fixes # (issue)
[https://trello.com/c/Trtu00CD](https://trello.com/c/Trtu00CD)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] New User Created
![image](https://user-images.githubusercontent.com/81938708/235132835-576deab9-7735-4ab4-8604-7da6d64e1c23.png)

- [x] The other songs imported with background job
![image](https://user-images.githubusercontent.com/81938708/235132995-9d83fed6-ff58-459c-89a9-ef239db07678.png)


# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
