### PR TITLE
Use modal for discover playlists

### DIFF
--- a/app/assets/stylesheets/components/_gallery_card.scss
+++ b/app/assets/stylesheets/components/_gallery_card.scss
@@ -2,14 +2,14 @@
   display: flex;
   justify-content: center;
   max-width: 380px;
-  margin: 0.8rem auto;
+  margin: 0.8rem auto 1.6rem;
 }
 
 .scene {
   display: inline-block;
   width: 90%;
   min-width: 340px;
-  aspect-ratio: 1/1.14;
+  aspect-ratio: 1/1;
   perspective: 600px;
 }
 
@@ -26,7 +26,7 @@
 
 .gallery-photo {
   align-items: center;
-  border: 7px solid $dark-gray ;
+  border: 7px solid $dark-gray;
   border-radius: 0.2em;
   transition: all 0.3s;
 
@@ -45,7 +45,7 @@
   position: absolute;
   backface-visibility: hidden;
   background: transparent;
-  padding: .6em;
+  padding: 0.6em;
   margin-top: 8%;
   height: 100%;
   width: 100%;
@@ -54,9 +54,9 @@
   // border: 1px solid rgba(255, 255, 255, 0.222);
   -webkit-backdrop-filter: blur(20px);
   backdrop-filter: blur(20px);
-  border-radius: .2rem;
+  border-radius: 0.2rem;
   transform: scale(1);
-  transition: all ease .3s;
+  transition: all ease 0.3s;
 
   p {
     color: $light-gray;
@@ -67,7 +67,7 @@
 .card__face--front {
   margin: 0 auto;
 
-  &:hover .gallery-photo{
+  &:hover .gallery-photo {
     box-shadow: 0px 0px 5px 1px rgba(255, 255, 255, 0.0754);
     // border: 1px solid rgba(255, 255, 255, 0.0754);
     transform: scale(1.02);
@@ -86,12 +86,19 @@
 .gallery-user {
   display: flex;
   position: relative;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
   padding-left: 0.5rem;
 
   a {
     position: absolute;
     width: 100%;
     height: 100%;
+  }
+
+  p {
+    margin: 0;
   }
 }
 

--- a/app/assets/stylesheets/components/_gallery_modal.scss
+++ b/app/assets/stylesheets/components/_gallery_modal.scss
@@ -1,0 +1,33 @@
+.gallery-modal {
+  justify-content: center;
+  align-items: center;
+  background-color: $light-gray;
+  z-index: 2;
+  position: fixed;
+  top: 10%;
+  left: 5%;
+  min-width: 90%;
+  margin: 0 auto;
+  padding: 0.25em;
+
+  background-color: rgba(255, 255, 255, 0.074);
+  border: 1px solid rgba(255, 255, 255, 0.222);
+  -webkit-backdrop-filter: blur(20px);
+  backdrop-filter: blur(20px);
+  border-radius: 0.5rem;
+
+  .logo {
+    width: 100px;
+    aspect-ratio: unset;
+    object-fit: unset;
+  }
+
+  a {
+    text-decoration: none;
+    color: $white;
+  }
+
+  .invisible {
+    visibility: hidden;
+  }
+}

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -6,6 +6,7 @@
 @import "event_form";
 @import "flickity";
 @import "gallery_card";
+@import "gallery_modal";
 @import "header";
 @import "login_spinner";
 @import "menu_bar";

--- a/app/javascript/controllers/gallery_card_controller.js
+++ b/app/javascript/controllers/gallery_card_controller.js
@@ -1,16 +1,28 @@
-import { Controller } from "@hotwired/stimulus"
+import { Controller } from "@hotwired/stimulus";
 
 // Connects to data-controller="gallery-card"
 export default class extends Controller {
-  static targets = ["card", "iframeCard"]
+  static targets = ["card", "modal", "playlistLink", "playlistIframe"];
 
-  click (e) {
-    const all_cards = document.querySelectorAll('[data-gallery-card-target="card"]')
-    all_cards.forEach((c)=>c.classList.remove("is-flipped"))
-    const iframeCards = document.querySelectorAll('[data-gallery-card-target="iframeCard"]')
-    iframeCards.forEach((iframe)=>iframe.classList.add("d-none"))
+  connect() {}
 
-    this.cardTarget.classList.add("is-flipped")
-    this.iframeCardTarget.classList.remove("d-none")
+  open(event) {
+    const playlistSpotifyId = event.currentTarget.dataset.playlistSpotifyId;
+    this.playlistIframeTarget.src = `https://open.spotify.com/embed/playlist/${playlistSpotifyId}?utm_source=generator&theme=0`;
+    this.playlistLinkTarget.href = `https://open.spotify.com/playlist/${playlistSpotifyId}`;
+
+    event.currentTarget.classList.add("is-flipped");
+
+    document.body.style.overflow = "hidden";
+    setTimeout((event) => {
+      this.modalTarget.classList.remove("invisible");
+    }, 1000);
+  }
+
+  close() {
+    document.body.style.overflow = "unset";
+
+    this.modalTarget.classList.add("invisible");
+    this.cardTargets.forEach((c) => c.classList.remove("is-flipped"));
   }
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -26,7 +26,7 @@
       <a href="https://open.spotify.com/" target="_blank"><%= image_tag "spotify_logo.png", {width: '100px'} %></a>
     </div>
     <div class="hide" data-homepage-target="hide">
-      <% current_user.others_playlists.sample(10).each do |playlist| %>
+      <% current_user.others_playlists.sample(20).each do |playlist| %>
         <%= render "shared/gallery_card", playlist: playlist %>
       <% end %>
     </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -19,7 +19,7 @@
     </div>
   </div>
   <!-- Gallery Feed -->
-  <div class="gallery-container">
+  <div class="gallery-container" data-controller="gallery-card">
     <div class="container mt-6 text-center hide" data-homepage-target="hide">
       <%# <h2 class="hide mb-3" data-homepage-target="hide">Discover Playlists</h2> %>
       <h2 class="mb-3">Discover Playlists</h2>
@@ -29,6 +29,21 @@
       <% current_user.others_playlists.sample(10).each do |playlist| %>
         <%= render "shared/gallery_card", playlist: playlist %>
       <% end %>
+    </div>
+    <!-- Iframe Modal -->
+    <div class="gallery-modal invisible" data-gallery-card-target="modal">
+      <div class="modal-container">
+        <div class="d-flex flex-row justify-content-between align-items-center" style="padding-bottom: 0.75em; padding-top: 0.25em;">
+          <div></div>
+          <div class='p-2' data-action="click->gallery-card#close">
+            <i class="fa-solid fa-xmark"></i>
+          </div>
+        </div>
+        <div class="text-center mb-2"><a href="" target="_blank" data-gallery-card-target="playlistLink">Listen on <%= image_tag "spotify_logo.png", class: 'logo' %></a></div>
+        <div class="iframe-wrapper d-flex justify-content-center">
+          <iframe id="playlist-show" style="border-radius:12px" src=<%= "https://open.spotify.com/embed/playlist/#{Playlist.first.spotify_id}?utm_source=generator&theme=0" %> width="100%" height="600" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy" data-gallery-card-target="playlistIframe"></iframe>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/shared/_gallery_card.html.erb
+++ b/app/views/shared/_gallery_card.html.erb
@@ -5,14 +5,14 @@
         <div class="gallery-photo">
           <%= cl_image_tag playlist.photo.key, crop: :fill, loading: "lazy" %>
         </div>
-        <div class="gallery-user d-flex align-items-center gap-3 mt-2">
-          <%= render 'shared/user_avatar_small', user: playlist.user %>
-          <p><small><%= playlist.user.nickname %></small></p>
-          <%= link_to "", user_playlists_path(playlist.user) %>
-        </div>
       </div>
       <div class="card__face card__face--back">
       </div>
+    </div>
+    <div class="gallery-user">
+      <%= render 'shared/user_avatar_small', user: playlist.user %>
+      <p><small><%= playlist.user.nickname %></small></p>
+      <%= link_to "", user_playlists_path(playlist.user) %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_gallery_card.html.erb
+++ b/app/views/shared/_gallery_card.html.erb
@@ -1,8 +1,8 @@
-<div class="gallery-card" data-controller="gallery-card">
+<div class="gallery-card">
   <div class="scene scene--card">
-    <div class="card" data-gallery-card-target="card">
+    <div class="card" data-gallery-card-target="card" data-action="click->gallery-card#open" data-playlist-spotify-id="<%= playlist.spotify_id %>">
       <div class="card__face card__face--front">
-        <div class="gallery-photo" data-action="click->gallery-card#click">
+        <div class="gallery-photo">
           <%= cl_image_tag playlist.photo.key, crop: :fill, loading: "lazy" %>
         </div>
         <div class="gallery-user d-flex align-items-center gap-3 mt-2">
@@ -11,8 +11,7 @@
           <%= link_to "", user_playlists_path(playlist.user) %>
         </div>
       </div>
-      <div class="card__face card__face--back d-none" data-gallery-card-target="iframeCard">
-        <iframe style="border-radius:12px;" src="https://open.spotify.com/embed/playlist/<%= playlist.spotify_id %>?utm_source=generator&theme=0" width="100%" height="100%" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+      <div class="card__face card__face--back">
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Description
- use a single modal and a iframe to load the playlist on the discover page.
- change the discover to use 20 songs to test on safari

Fixes # (issue)
[https://trello.com/c/m8YB22zN](https://trello.com/c/m8YB22zN)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] Discover page with playlist opened
![image](https://user-images.githubusercontent.com/81938708/236415872-28b4950b-c256-4773-8c58-463feae667b8.png)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added proof(eg. screenshots) that prove my fix is effective or that my feature works
